### PR TITLE
Support for CodeDeploy deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This action requires the following minimum set of permissions:
 
 Note: the policy above assumes the account has opted in to the ECS long ARN format.
 
-## CodeDeploy Support
+## AWS CodeDeploy Support
 
 For ECS services that uses the `CODE_DEPLOY` deployment controller, additional configuration is needed for this action:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This action requires the following minimum set of permissions:
             "ecs:DescribeServices"
          ],
          "Resource":[
-            "arn:aws:ecs:region:<aws_account_id>:service/<cluster_name>/<service_name>"
+            "arn:aws:ecs:<region>:<aws_account_id>:service/<cluster_name>/<service_name>"
          ]
       }
    ]
@@ -71,6 +71,70 @@ This action requires the following minimum set of permissions:
 ```
 
 Note: the policy above assumes the account has opted in to the ECS long ARN format.
+
+## CodeDeploy Support
+
+For ECS services that uses the `CODE_DEPLOY` deployment controller, additional configuration is needed for this action:
+
+```yaml
+    - name: Deploy to Amazon ECS
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        service: my-service
+        cluster: my-cluster
+        wait-for-service-stability: true
+        codedeploy-appspec: appspec.json
+        codedeploy-application: my-codedeploy-application
+        codedeploy-deployment-group: my-codedeploy-deployment-group
+```
+
+The minimal permissions require access to CodeDeploy:
+
+```
+{
+   "Version":"2012-10-17",
+   "Statement":[
+      {
+         "Sid":"RegisterTaskDefinition",
+         "Effect":"Allow",
+         "Action":[
+            "ecs:RegisterTaskDefinition"
+         ],
+         "Resource":"*"
+      },
+      {
+         "Sid":"PassRolesInTaskDefinition",
+         "Effect":"Allow",
+         "Action":[
+            "iam:PassRole"
+         ],
+         "Resource":[
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
+         ]
+      },
+      {
+         "Sid":"DeployService",
+         "Effect":"Allow",
+         "Action":[
+            "ecs:DescribeServices",
+            "codedeploy:GetDeploymentGroup",
+            "codedeploy:CreateDeployment",
+            "codedeploy:GetDeployment",
+            "codedeploy:GetDeploymentConfig",
+            "codedeploy:RegisterApplicationRevision"
+         ],
+         "Resource":[
+            "arn:aws:ecs:<region>:<aws_account_id>:service/<cluster_name>/<service_name>",
+            "arn:aws:codedeploy:<region>:<aws_account_id>:deploymentgroup:<application_name>/<deployment_group_name>",
+            "arn:aws:codedeploy:<region>:<aws_account_id>:deploymentconfig:*",
+            "arn:aws:codedeploy:<region>:<aws_account_id>:application:<application_name>"
+         ]
+      }
+   ]
+}
+```
 
 ## License Summary
 

--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,13 @@ inputs:
     description: 'Whether to wait for the ECS service to reach stable state after deploying the new task definition. Valid value is "true". Will default to not waiting.'
     required: false
   codedeploy-appspec:
-    description: "The path to the CodeDeploy AppSpec file, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'appspec.yaml'."
+    description: "The path to the AWS CodeDeploy AppSpec file, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'appspec.yaml'."
     required: false
   codedeploy-application:
-    description: "The name of the CodeDeploy application, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'AppECS-{cluster}-{service}'."
+    description: "The name of the AWS CodeDeploy application, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'AppECS-{cluster}-{service}'."
     required: false
   codedeploy-deployment-group:
-    description: "The name of the CodeDeploy deployment group, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'DgpECS-{cluster}-{service}'."
+    description: "The name of the AWS CodeDeploy deployment group, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'DgpECS-{cluster}-{service}'."
     required: false
 outputs:
   task-definition-arn:

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,20 @@ inputs:
   wait-for-service-stability:
     description: 'Whether to wait for the ECS service to reach stable state after deploying the new task definition. Valid value is "true". Will default to not waiting.'
     required: false
+  codedeploy-appspec:
+    description: "The path to the CodeDeploy AppSpec file, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'appspec.yaml'."
+    required: false
+  codedeploy-application:
+    description: "The name of the CodeDeploy application, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'AppECS-{cluster}-{service}'."
+    required: false
+  codedeploy-deployment-group:
+    description: "The name of the CodeDeploy deployment group, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'DgpECS-{cluster}-{service}'."
+    required: false
 outputs:
   task-definition-arn:
     description: 'The ARN of the registered ECS task definition'
+  codedeploy-deployment-id:
+    description: 'The deployment ID of the CodeDeploy deployment (if the ECS service uses the CODE_DEPLOY deployment controller'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -1,10 +1,143 @@
 const path = require('path');
 const core = require('@actions/core');
 const aws = require('aws-sdk');
+const yaml = require('yaml');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const CODE_DEPLOY_WAIT_BUFFER_MINUTES = 10;
+const CODE_DEPLOY_MAX_WAIT_MINUTES = 360;  // 6 hours
+const CODE_DEPLOY_MIN_WAIT_MINUTES = 30;
+const CODE_DEPLOY_WAIT_DEFAULT_DELAY_SEC = 15;
+
+// Deploy to a service that uses the 'ECS' deployment controller
+async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService) {
+  core.debug('Updating the service');
+  await ecs.updateService({
+    cluster: clusterName,
+    service: service,
+    taskDefinition: taskDefArn
+  }).promise();
+
+  // Wait for service stability
+  if (waitForService && waitForService.toLowerCase() === 'true') {
+    core.debug('Waiting for the service to become stable');
+    await ecs.waitFor('servicesStable', {
+      services: [service],
+      cluster: clusterName
+    }).promise();
+  } else {
+    core.debug('Not waiting for the service to become stable');
+  }
+}
+
+// Find value in a CodeDeploy AppSpec file with a case-insensitive key
+function findAppSpecValue(obj, keyName) {
+  return obj[findAppSpecKey(obj, keyName)];
+}
+
+function findAppSpecKey(obj, keyName) {
+  if (!obj) {
+    throw new Error(`AppSpec file must include property '${keyName}'`);
+  }
+
+  const keyToMatch = keyName.toLowerCase();
+
+  for (var key in obj) {
+    if (key.toLowerCase() == keyToMatch) {
+      return key;
+    }
+  }
+
+  throw new Error(`AppSpec file must include property '${keyName}'`);
+}
+
+// Deploy to a service that uses the 'CODE_DEPLOY' deployment controller
+async function createCodeDeployDeployment(codedeploy, clusterName, service, taskDefArn, waitForService) {
+  core.debug('Updating AppSpec file with new task definition ARN');
+
+  let codeDeployAppSpecFile = core.getInput('codedeploy-appspec', { required : false });
+  codeDeployAppSpecFile = codeDeployAppSpecFile ? codeDeployAppSpecFile : 'appspec.yaml';
+
+  let codeDeployApp = core.getInput('codedeploy-application', { required: false });
+  codeDeployApp = codeDeployApp ? codeDeployApp : `AppECS-${clusterName}-${service}`;
+
+  let codeDeployGroup = core.getInput('codedeploy-deployment-group', { required: false });
+  codeDeployGroup = codeDeployGroup ? codeDeployGroup : `DgpECS-${clusterName}-${service}`;
+
+  let deploymentGroupDetails = await codedeploy.getDeploymentGroup({
+    applicationName: codeDeployApp,
+    deploymentGroupName: codeDeployGroup
+  }).promise();
+  deploymentGroupDetails = deploymentGroupDetails.deploymentGroupInfo;
+
+  // Insert the task def ARN into the appspec file
+  const appSpecPath = path.isAbsolute(codeDeployAppSpecFile) ?
+    codeDeployAppSpecFile :
+    path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
+  const fileContents = fs.readFileSync(appSpecPath, 'utf8');
+  const appSpecContents = yaml.parse(fileContents);
+
+  for (var resource of findAppSpecValue(appSpecContents, 'resources')) {
+    for (var name in resource) {
+      const resourceContents = resource[name];
+      const properties = findAppSpecValue(resourceContents, 'properties');
+      const taskDefKey = findAppSpecKey(properties, 'taskDefinition');
+      properties[taskDefKey] = taskDefArn;
+    }
+  }
+
+  const appSpecString = JSON.stringify(appSpecContents);
+  const appSpecHash = crypto.createHash('sha256').update(appSpecString).digest('hex');
+
+  // Start the deployment with the updated appspec contents
+  core.debug('Starting CodeDeploy deployment');
+  const createDeployResponse = await codedeploy.createDeployment({
+    applicationName: codeDeployApp,
+    deploymentGroupName: codeDeployGroup,
+    revision: {
+      revisionType: 'AppSpecContent',
+      appSpecContent: {
+        content: appSpecString,
+        sha256: appSpecHash
+      }
+    }
+  }).promise();
+  core.setOutput('codedeploy-deployment-id', createDeployResponse.deploymentId);
+
+  // Wait for deployment to complete
+  if (waitForService && waitForService.toLowerCase() === 'true') {
+    // Determine wait time
+    const deployReadyWaitMin = deploymentGroupDetails.blueGreenDeploymentConfiguration.deploymentReadyOption.waitTimeInMinutes;
+    const terminationWaitMin = deploymentGroupDetails.blueGreenDeploymentConfiguration.terminateBlueInstancesOnDeploymentSuccess.terminationWaitTimeInMinutes;
+    let totalWaitMin = deployReadyWaitMin + terminationWaitMin + CODE_DEPLOY_WAIT_BUFFER_MINUTES;
+    if (totalWaitMin > CODE_DEPLOY_MAX_WAIT_MINUTES) {
+      totalWaitMin = CODE_DEPLOY_MAX_WAIT_MINUTES;
+    }
+    if (totalWaitMin < CODE_DEPLOY_MIN_WAIT_MINUTES) {
+      totalWaitMin = CODE_DEPLOY_MIN_WAIT_MINUTES;
+    }
+    const maxAttempts = (totalWaitMin * 60) / CODE_DEPLOY_WAIT_DEFAULT_DELAY_SEC;
+
+    core.debug(`Waiting for the deployment to complete. Will wait for ${totalWaitMin} minutes`);
+    await codedeploy.waitFor('deploymentSuccessful', {
+      deploymentId: createDeployResponse.deploymentId,
+      $waiter: {
+        delay: CODE_DEPLOY_WAIT_DEFAULT_DELAY_SEC,
+        maxAttempts: maxAttempts
+      }
+    }).promise();
+  } else {
+    core.debug('Not waiting for the deployment to complete');
+  }
+}
 
 async function run() {
   try {
     const ecs = new aws.ECS({
+      customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions'
+    });
+    const codedeploy = new aws.CodeDeploy({
       customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions'
     });
 
@@ -19,36 +152,48 @@ async function run() {
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
       taskDefinitionFile :
       path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
-    const taskDefContents = require(taskDefPath);
+    const fileContents = fs.readFileSync(taskDefPath, 'utf8');
+    const taskDefContents = yaml.parse(fileContents);
     const registerResponse = await ecs.registerTaskDefinition(taskDefContents).promise();
     const taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
     core.setOutput('task-definition-arn', taskDefArn);
 
     // Update the service with the new task definition
     if (service) {
-      core.debug('Updating the service');
       const clusterName = cluster ? cluster : 'default';
-      await ecs.updateService({
-        cluster: clusterName,
-        service: service,
-        taskDefinition: taskDefArn
+
+      // Determine the deployment controller
+      const describeResponse = await ecs.describeServices({
+        services: [service],
+        cluster: clusterName
       }).promise();
 
-      // Wait for service stability
-      if (waitForService && waitForService.toLowerCase() === 'true') {
-        core.debug('Waiting for the service to become stable');
-        await ecs.waitFor('servicesStable', {
-          services: [service],
-          cluster: clusterName
-        }).promise();
+      if (describeResponse.failures && describeResponse.failures.length > 0) {
+        const failure = describeResponse.failures[0];
+        throw new Error(`${failure.arn} is ${failure.reason}`);
+      }
+
+      const serviceResponse = describeResponse.services[0];
+      if (serviceResponse.status != 'ACTIVE') {
+        throw new Error(`Service is ${serviceResponse.status}`);
+      }
+
+      if (!serviceResponse.deploymentController) {
+        // Service uses the 'ECS' deployment controller, so we can call UpdateService
+        await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService);
+      } else if (serviceResponse.deploymentController.type == 'CODE_DEPLOY') {
+        // Service uses CodeDeploy, so we should start a CodeDeploy deployment
+        await createCodeDeployDeployment(codedeploy, clusterName, service, taskDefArn, waitForService);
       } else {
-        core.debug('Not waiting for the service to become stable');
+        throw new Error(`Unsupported deployment controller: ${serviceResponse.deploymentController.type}`);
       }
     } else {
       core.debug('Service was not specified, no service updated');
     }
   }
   catch (error) {
+    core.debug(error);
+    core.debug(error.stack);
     core.setFailed(error.message);
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,17 +1,30 @@
 const run = require('.');
 const core = require('@actions/core');
+const fs = require('fs');
+const path = require('path');
 
 jest.mock('@actions/core');
+jest.mock('fs');
 
 const mockEcsRegisterTaskDef = jest.fn();
 const mockEcsUpdateService = jest.fn();
+const mockEcsDescribeServices = jest.fn();
 const mockEcsWaiter = jest.fn();
+const mockCodeDeployCreateDeployment = jest.fn();
+const mockCodeDeployGetDeploymentGroup = jest.fn();
+const mockCodeDeployWaiter = jest.fn();
 jest.mock('aws-sdk', () => {
     return {
         ECS: jest.fn(() => ({
             registerTaskDefinition: mockEcsRegisterTaskDef,
             updateService: mockEcsUpdateService,
+            describeServices: mockEcsDescribeServices,
             waitFor: mockEcsWaiter
+        })),
+        CodeDeploy: jest.fn(() => ({
+            createDeployment: mockCodeDeployCreateDeployment,
+            getDeploymentGroup: mockCodeDeployGetDeploymentGroup,
+            waitFor: mockCodeDeployWaiter
         }))
     };
 });
@@ -29,7 +42,29 @@ describe('Deploy to ECS', () => {
 
         process.env = Object.assign(process.env, { GITHUB_WORKSPACE: __dirname });
 
-        jest.mock('./task-definition.json', () => ({ family: 'task-def-family' }), { virtual: true });
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            if (pathInput == path.join(process.env.GITHUB_WORKSPACE, 'appspec.yaml')) {
+                return `
+                Resources:
+                - TargetService:
+                    Type: AWS::ECS::Service
+                    Properties:
+                      TaskDefinition: helloworld
+                      LoadBalancerInfo:
+                        ContainerName: web
+                        ContainerPort: 80`;
+            }
+
+            if (pathInput == path.join(process.env.GITHUB_WORKSPACE, 'task-definition.json')) {
+                return JSON.stringify({ family: 'task-def-family' });
+            }
+
+            throw new Error(`Unknown path ${pathInput}`);
+        });
 
         mockEcsRegisterTaskDef.mockImplementation(() => {
             return {
@@ -47,7 +82,55 @@ describe('Deploy to ECS', () => {
             };
         });
 
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'ACTIVE'
+                        }]
+                    });
+                }
+            };
+        });
+
         mockEcsWaiter.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({});
+                }
+            };
+        });
+
+        mockCodeDeployCreateDeployment.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({ deploymentId: 'deployment-1' });
+                }
+            };
+        });
+
+        mockCodeDeployGetDeploymentGroup.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        deploymentGroupInfo: {
+                            blueGreenDeploymentConfiguration: {
+                                deploymentReadyOption: {
+                                    waitTimeInMinutes: 60
+                                },
+                                terminateBlueInstancesOnDeploymentSuccess: {
+                                    terminationWaitTimeInMinutes: 30
+                                }
+                            }
+                        }
+                    });
+                }
+            };
+        });
+
+        mockCodeDeployWaiter.mockImplementation(() => {
             return {
                 promise() {
                     return Promise.resolve({});
@@ -58,8 +141,13 @@ describe('Deploy to ECS', () => {
 
     test('registers the task definition contents and updates the service', async () => {
         await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            services: ['service-456']
+        });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
             service: 'service-456',
@@ -68,11 +156,211 @@ describe('Deploy to ECS', () => {
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
     });
 
-    test('registers the task definition contents at an absolute path', async () => {
-        core.getInput = jest.fn().mockReturnValueOnce('/hello/task-definition.json');
-        jest.mock('/hello/task-definition.json', () => ({ family: 'task-def-family-absolute-path' }), { virtual: true });
+    test('registers the task definition contents and creates a CodeDeploy deployment', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('service-456')         // service
+            .mockReturnValueOnce('cluster-789')         // cluster
+            .mockReturnValueOnce('TRUE');               // wait-for-service-stability
+
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'ACTIVE',
+                            deploymentController: {
+                                type: 'CODE_DEPLOY'
+                            }
+                        }]
+                    });
+                }
+            };
+        });
 
         await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            services: ['service-456']
+        });
+
+        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1, {
+            applicationName: 'AppECS-cluster-789-service-456',
+            deploymentGroupName: 'DgpECS-cluster-789-service-456',
+            revision: {
+                revisionType: 'AppSpecContent',
+                appSpecContent: {
+                  content: JSON.stringify({
+                      Resources: [{
+                          TargetService: {
+                              Type: 'AWS::ECS::Service',
+                              Properties: {
+                                TaskDefinition: 'task:def:arn',
+                                LoadBalancerInfo: {
+                                    ContainerName: "web",
+                                    ContainerPort: 80
+                                }
+                              }
+                          }
+                      }]
+                    }),
+                  sha256: '0911d1e99f48b492e238d1284d8ddb805382d33e1d1fc74ffadf37d8b7e6d096'
+                }
+            }
+        });
+
+        expect(mockCodeDeployWaiter).toHaveBeenNthCalledWith(1, 'deploymentSuccessful', {
+            deploymentId: 'deployment-1',
+            $waiter: {
+                delay: 15,
+                maxAttempts: 400
+            }
+        });
+
+        expect(mockEcsUpdateService).toHaveBeenCalledTimes(0);
+        expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
+    });
+
+    test('does not wait for a CodeDeploy deployment, parses JSON appspec file', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('service-456')         // service
+            .mockReturnValueOnce('cluster-789')         // cluster
+            .mockReturnValueOnce('false')               // wait-for-service-stability
+            .mockReturnValueOnce('/hello/appspec.json') // codedeploy-appspec
+            .mockReturnValueOnce('MyApplication')       // codedeploy-application
+            .mockReturnValueOnce('MyDeploymentGroup');  // codedeploy-deployment-group
+
+        fs.readFileSync.mockReturnValue(`
+            {
+                "Resources": [
+                    {
+                        "TargetService": {
+                            "Type": "AWS::ECS::Service",
+                            "Properties": {
+                                "TaskDefinition": "helloworld",
+                                "LoadBalancerInfo": {
+                                    "ContainerName": "web",
+                                    "ContainerPort": 80
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        `);
+
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            if (pathInput == path.join('/hello/appspec.json')) {
+                return `
+                {
+                    "Resources": [
+                        {
+                            "TargetService": {
+                                "Type": "AWS::ECS::Service",
+                                "Properties": {
+                                    "TaskDefinition": "helloworld",
+                                    "LoadBalancerInfo": {
+                                        "ContainerName": "web",
+                                        "ContainerPort": 80
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }`;
+            }
+
+            if (pathInput == path.join(process.env.GITHUB_WORKSPACE, 'task-definition.json')) {
+                return JSON.stringify({ family: 'task-def-family' });
+            }
+
+            throw new Error(`Unknown path ${pathInput}`);
+        });
+
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'ACTIVE',
+                            deploymentController: {
+                                type: 'CODE_DEPLOY'
+                            }
+                        }]
+                    });
+                }
+            };
+        });
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            services: ['service-456']
+        });
+
+        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1, {
+            applicationName: 'MyApplication',
+            deploymentGroupName: 'MyDeploymentGroup',
+            revision: {
+                revisionType: 'AppSpecContent',
+                appSpecContent: {
+                  content: JSON.stringify({
+                      Resources: [{
+                          TargetService: {
+                              Type: 'AWS::ECS::Service',
+                              Properties: {
+                                TaskDefinition: 'task:def:arn',
+                                LoadBalancerInfo: {
+                                    ContainerName: "web",
+                                    ContainerPort: 80
+                                }
+                              }
+                          }
+                      }]
+                    }),
+                  sha256: '0911d1e99f48b492e238d1284d8ddb805382d33e1d1fc74ffadf37d8b7e6d096'
+                }
+            }
+        });
+
+        expect(mockCodeDeployWaiter).toHaveBeenCalledTimes(0);
+        expect(mockEcsUpdateService).toHaveBeenCalledTimes(0);
+        expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
+    });
+
+    test('registers the task definition contents at an absolute path', async () => {
+        core.getInput = jest.fn().mockReturnValueOnce('/hello/task-definition.json');
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            if (pathInput == '/hello/task-definition.json') {
+                return JSON.stringify({ family: 'task-def-family-absolute-path' });
+            }
+
+            throw new Error(`Unknown path ${pathInput}`);
+        });
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
 
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family-absolute-path'});
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
@@ -87,9 +375,14 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('TRUE');               // wait-for-service-stability
 
         await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
 
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            services: ['service-456']
+        });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
             service: 'service-456',
@@ -108,9 +401,14 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('service-456');         // service
 
         await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
 
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
+            cluster: 'default',
+            services: ['service-456']
+        });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'default',
             service: 'service-456',
@@ -124,10 +422,96 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('task-definition.json'); // task-definition
 
         await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
 
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsDescribeServices).toHaveBeenCalledTimes(0);
         expect(mockEcsUpdateService).toHaveBeenCalledTimes(0);
+    });
+
+    test('error caught if AppSpec file is not formatted correctly', async () => {
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'ACTIVE',
+                            deploymentController: {
+                                type: 'CODE_DEPLOY'
+                            }
+                        }]
+                    });
+                }
+            };
+        });
+        fs.readFileSync.mockReturnValue("hello: world");
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith("AppSpec file must include property 'resources'");
+    });
+
+    test('error is caught if service does not exist', async () => {
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [{
+                            reason: 'MISSING',
+                            arn: 'hello'
+                        }],
+                        services: []
+                    });
+                }
+            };
+        });
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('hello is MISSING');
+    });
+
+    test('error is caught if service is inactive', async () => {
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'INACTIVE'
+                        }]
+                    });
+                }
+            };
+        });
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Service is INACTIVE');
+    });
+
+    test('error is caught if service uses external deployment controller', async () => {
+        mockEcsDescribeServices.mockImplementation(() => {
+            return {
+                promise() {
+                    return Promise.resolve({
+                        failures: [],
+                        services: [{
+                            status: 'ACTIVE',
+                            deploymentController: {
+                                type: 'EXTERNAL'
+                            }
+                        }]
+                    });
+                }
+            };
+        });
+
+        await run();
+
+        expect(core.setFailed).toBeCalledWith('Unsupported deployment controller: EXTERNAL');
     });
 
     test('error is caught by core.setFailed', async () => {

--- a/index.test.js
+++ b/index.test.js
@@ -156,6 +156,20 @@ describe('Deploy to ECS', () => {
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
     });
 
+    test('cleans null keys out of the task definition contents', async () => {
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            return '{ "ipcMode": null, "family": "task-def-family" }';
+        });
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
+    });
+
     test('registers the task definition contents and creates a CodeDeploy deployment', async () => {
         core.getInput = jest
             .fn()

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
@@ -4270,6 +4278,11 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5390,6 +5403,14 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
+      "requires": {
+        "@babel/runtime": "^7.6.3"
+      }
     },
     "yargs": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/aws-actions/amazon-ecs-deploy-task-definition#readme",
   "dependencies": {
     "@actions/core": "^1.2.0",
-    "aws-sdk": "^2.573.0"
+    "aws-sdk": "^2.573.0",
+    "yaml": "^1.7.2"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.20.5",


### PR DESCRIPTION
Duplicate much of the logic from the `aws ecs deploy` command into this action, so that Actions can be used to deploy to CodeDeploy-using ECS services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
