### PR TITLE
fix: Ignore task definition fields that are Describe outputs, but not Register inputs

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -170,6 +170,20 @@ describe('Deploy to ECS', () => {
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
     });
 
+    test('cleans invalid keys out of the task definition contents', async () => {
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            return '{ "compatibilities": ["EC2"], "taskDefinitionArn": "arn:aws...:task-def-family:1", "family": "task-def-family", "revision": 1, "status": "ACTIVE" }';
+        });
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
+    });
+
     test('registers the task definition contents and creates a CodeDeploy deployment', async () => {
         core.getInput = jest
             .fn()


### PR DESCRIPTION
Fixes #22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
