### PR TITLE
fix: clean null values out of arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,11 +70,25 @@ function isEmptyValue(value) {
     return true;
   }
 
-  if (Array.isArray(value) && value.length === 0) {
+  if (Array.isArray(value)) {
+    for (var element of value) {
+      if (!isEmptyValue(element)) {
+        // the array has at least one non-empty element
+        return false;
+      }
+    }
+    // the array has no non-empty elements
     return true;
   }
 
-  if (typeof value === 'object' && Object.values(value).length === 0) {
+  if (typeof value === 'object') {
+    for (var childValue of Object.values(value)) {
+      if (!isEmptyValue(childValue)) {
+        // the object has at least one non-empty property
+        return false;
+      }
+    }
+    // the object has no non-empty property
     return true;
   }
 
@@ -86,15 +100,8 @@ function emptyValueReplacer(_, value) {
     return undefined;
   }
 
-  if (typeof value === 'object') {
-    for (var childValue of Object.values(value)) {
-      if (!isEmptyValue(childValue)) {
-        // the object has at least one non-empty property
-        return value;
-      }
-    }
-    // the object has no non-empty property
-    return undefined;
+  if (Array.isArray(value)) {
+    return value.filter(e => !isEmptyValue(e));
   }
 
   return value;

--- a/index.test.js
+++ b/index.test.js
@@ -198,7 +198,37 @@ describe('Deploy to ECS', () => {
                 throw new Error(`Wrong encoding ${encoding}`);
             }
 
-            return '{ "memory": "", "containerDefinitions": [ { "name": "sample-container", "logConfiguration": {}, "repositoryCredentials": { "credentialsParameter": "" }, "cpu": 0, "essential": false } ], "requiresCompatibilities": [ "EC2" ], "family": "task-def-family" }';
+            return `
+            {
+                "memory": "",
+                "containerDefinitions": [ {
+                    "name": "sample-container",
+                    "logConfiguration": {},
+                    "repositoryCredentials": { "credentialsParameter": "" },
+                    "command": [
+                        ""
+                    ],
+                    "environment": [
+                        {
+                            "name": "hello",
+                            "value": "world"
+                        },
+                        {
+                            "name": "",
+                            "value": ""
+                        }
+                    ],
+                    "secretOptions": [ {
+                        "name": "",
+                        "valueFrom": ""
+                    } ],
+                    "cpu": 0,
+                    "essential": false
+                } ],
+                "requiresCompatibilities": [ "EC2" ],
+                "family": "task-def-family"
+            }
+            `;
         });
 
         await run();
@@ -209,7 +239,11 @@ describe('Deploy to ECS', () => {
                 {
                     name: 'sample-container',
                     cpu: 0,
-                    essential: false
+                    essential: false,
+                    environment: [{
+                        name: 'hello',
+                        value: 'world'
+                    }]
                 }
             ],
             requiresCompatibilities: [ 'EC2' ]


### PR DESCRIPTION
Fixes #53 

The following task definition input for the action:
```
      "logConfiguration": {
        "logDriver": "awsfirelens",
        "options": {
          "KeyName": ""
        },
        "secretOptions": [
          {
            "name": "",
            "valueFrom": ""
          }
        ]
      },
```
currently generates the following input to RegisterTaskDefinition:
```
      "logConfiguration": {
        "logDriver": "awsfirelens",
        "secretOptions": [
          null
        ]
      },
```

Because of the null value, the only error message is `Cannot read property 'name' of null`.  This PR removes all the null values so that a proper error message is given to the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
