### PR TITLE
fix: forceNewDeployment to be a boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,8 +223,8 @@ async function run() {
       waitForMinutes = MAX_WAIT_MINUTES;
     }
 
-    const forceNewDeployInput = core.getInput('force-new-deployment', { required: false })
-    const forceNewDeployment = forceNewDeployInput != undefined && forceNewDeployInput.toLocaleLowerCase === "true" ? true : false;
+    const forceNewDeployInput = core.getInput('force-new-deployment', { required: false });
+    const forceNewDeployment = forceNewDeployInput != undefined && (forceNewDeployInput.toLowerCase === 'true' || forceNewDeployInput);
     
     // Register the task definition
     core.debug('Registering the task definition');

--- a/index.js
+++ b/index.js
@@ -222,8 +222,10 @@ async function run() {
     if (waitForMinutes > MAX_WAIT_MINUTES) {
       waitForMinutes = MAX_WAIT_MINUTES;
     }
-    const forceNewDeployment = core.getInput('force-new-deployment', { required: false }) || false;
 
+    const forceNewDeployInput = core.getInput('force-new-deployment', { required: false })
+    const forceNewDeployment = forceNewDeployInput != undefined && forceNewDeployInput.toLocaleLowerCase === "true" ? true : false;
+    
     // Register the task definition
     core.debug('Registering the task definition');
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?

--- a/index.test.js
+++ b/index.test.js
@@ -755,7 +755,7 @@ describe('Deploy to ECS', () => {
             cluster: 'cluster-789',
             service: 'service-456',
             taskDefinition: 'task:def:arn',
-            forceNewDeployment: false
+            forceNewDeployment: true
         });
     });
 

--- a/index.test.js
+++ b/index.test.js
@@ -755,7 +755,7 @@ describe('Deploy to ECS', () => {
             cluster: 'cluster-789',
             service: 'service-456',
             taskDefinition: 'task:def:arn',
-            forceNewDeployment: true
+            forceNewDeployment: false
         });
     });
 


### PR DESCRIPTION
*This PR fix the Issue [#133](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/133)*

*Description of changes:*
This issue was occurring due to incorrect data type of the forceNewDeployment parameter.
In order to fix this issue need to type caste the value of the forceNewDeployment parameter from string to boolean. 
