### PR TITLE
fix: forceNewDeployment input to take a boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ async function run() {
       waitForMinutes = MAX_WAIT_MINUTES;
     }
 
-    const forceNewDeployInput = core.getInput('force-new-deployment', { required: false });
+    const forceNewDeployInput = core.getInput('force-new-deployment', { required: false }) || false;
     const forceNewDeployment = forceNewDeployInput != undefined && (forceNewDeployInput.toLowerCase === 'true' || forceNewDeployInput);
     
     // Register the task definition


### PR DESCRIPTION
Return false if there is no forceNewDeployment value passed in as input.