### PR TITLE
fix: ignore additional fields from task definition input

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ const IGNORED_TASK_DEFINITION_ATTRIBUTES = [
   'taskDefinitionArn',
   'requiresAttributes',
   'revision',
-  'status'
+  'status',
+  'registeredAt',
+  'deregisteredAt',
+  'registeredBy'
 ];
 
 // Deploy to a service that uses the 'ECS' deployment controller

--- a/index.test.js
+++ b/index.test.js
@@ -227,6 +227,7 @@ describe('Deploy to ECS', () => {
                     "essential": false
                 } ],
                 "requiresCompatibilities": [ "EC2" ],
+                "registeredAt": 1611690781,
                 "family": "task-def-family"
             }
             `;


### PR DESCRIPTION
Addresses https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/164