### PR TITLE
fix: allow empty values in proxyConfiguration.properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@ function removeIgnoredAttributes(taskDef) {
 
 function maintainAppMeshConfiguration(taskDef) {
     if ('proxyConfiguration' in taskDef && taskDef.proxyConfiguration.type == 'APPMESH' && taskDef.proxyConfiguration.properties.length > 0) {
-        taskDef.proxyConfiguration.properties.forEach((value, index, arr) => {
-            if (!('value' in value)) {
+        taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
+            if (!('value' in property)) {
                 arr[index].value = '';
             }
         });

--- a/index.js
+++ b/index.js
@@ -135,9 +135,11 @@ function maintainAppMeshConfiguration(taskDef) {
             if (!('value' in property)) {
                 arr[index].value = '';
             }
+            if (!('name' in property)) {
+                arr[index].name = '';
+            }
         });
     }
-
     return taskDef;
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -252,6 +252,133 @@ describe('Deploy to ECS', () => {
         });
     });
 
+    test('maintains empty keys in proxyConfiguration.properties for APPMESH', async () => {
+        fs.readFileSync.mockImplementation((pathInput, encoding) => {
+            if (encoding != 'utf8') {
+                throw new Error(`Wrong encoding ${encoding}`);
+            }
+
+            return `
+            {
+                "memory": "",
+                "containerDefinitions": [ {
+                    "name": "sample-container",
+                    "logConfiguration": {},
+                    "repositoryCredentials": { "credentialsParameter": "" },
+                    "command": [
+                        ""
+                    ],
+                    "environment": [
+                        {
+                            "name": "hello",
+                            "value": "world"
+                        },
+                        {
+                            "name": "",
+                            "value": ""
+                        }
+                    ],
+                    "secretOptions": [ {
+                        "name": "",
+                        "valueFrom": ""
+                    } ],
+                    "cpu": 0,
+                    "essential": false
+                } ],
+                "requiresCompatibilities": [ "EC2" ],
+                "registeredAt": 1611690781,
+                "family": "task-def-family",
+                "proxyConfiguration": {
+                    "type": "APPMESH",
+                    "containerName": "envoy",
+                    "properties": [
+                        {
+                            "name": "ProxyIngressPort",
+                            "value": "15000"
+                        },
+                        {
+                            "name": "AppPorts",
+                            "value": "1234"
+                        },
+                        {
+                            "name": "EgressIgnoredIPs",
+                            "value": "169.254.170.2,169.254.169.254"
+                        },
+                        {
+                            "name": "IgnoredGID",
+                            "value": ""
+                        },
+                        {
+                            "name": "EgressIgnoredPorts",
+                            "value": ""
+                        },
+                        {
+                            "name": "IgnoredUID",
+                            "value": "1337"
+                        },
+                        {
+                            "name": "ProxyEgressPort",
+                            "value": "15001"
+                        }
+                    ]
+                }
+            }
+            `;
+        });
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, {
+            family: 'task-def-family',
+            containerDefinitions: [
+                {
+                    name: 'sample-container',
+                    cpu: 0,
+                    essential: false,
+                    environment: [{
+                        name: 'hello',
+                        value: 'world'
+                    }]
+                }
+            ],
+            requiresCompatibilities: [ 'EC2' ],
+            proxyConfiguration: {
+                type: "APPMESH",
+                containerName: "envoy",
+                properties: [
+                    {
+                        name: "ProxyIngressPort",
+                        value: "15000"
+                    },
+                    {
+                        name: "AppPorts",
+                        value: "1234"
+                    },
+                    {
+                        name: "EgressIgnoredIPs",
+                        value: "169.254.170.2,169.254.169.254"
+                    },
+                    {
+                        name: "IgnoredGID",
+                        value: ""
+                    },
+                    {
+                        name: "EgressIgnoredPorts",
+                        value: ""
+                    },
+                    {
+                        name: "IgnoredUID",
+                        value: "1337"
+                    },
+                    {
+                        name: "ProxyEgressPort",
+                        value: "15001"
+                    }
+                ]
+            }
+        });
+    });
+
     test('cleans invalid keys out of the task definition contents', async () => {
         fs.readFileSync.mockImplementation((pathInput, encoding) => {
             if (encoding != 'utf8') {

--- a/index.test.js
+++ b/index.test.js
@@ -319,6 +319,9 @@ describe('Deploy to ECS', () => {
                         {
                             "name": "ProxyEgressPort",
                             "value": "15001"
+                        },
+                        {
+                            "value": "some-value"
                         }
                     ]
                 }
@@ -373,6 +376,10 @@ describe('Deploy to ECS', () => {
                     {
                         name: "ProxyEgressPort",
                         value: "15001"
+                    },
+                    {
+                        name: "",
+                        value: "some-value"
                     }
                 ]
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2714,7 +2714,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -3078,6 +3079,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -4781,6 +4783,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -4795,6 +4798,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -5600,7 +5604,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6306,7 +6311,8 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.2.0",


### PR DESCRIPTION
Fixes: #163

App Mesh requires the properties array contain a name and a value for each key. The `cleanNullKeys` removes the values that are empty strings. This commit loops through the properties array if the proxyConfiguration.type is APPMESH and restores any deleted values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
