### PR TITLE
fix: Cannot read property 'length' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function removeIgnoredAttributes(taskDef) {
 }
 
 function maintainAppMeshConfiguration(taskDef) {
-    if ('proxyConfiguration' in taskDef && taskDef.proxyConfiguration.type == 'APPMESH' && taskDef.proxyConfiguration.properties.length > 0) {
+    if ('proxyConfiguration' in taskDef && taskDef.proxyConfiguration && taskDef.proxyConfiguration.type == 'APPMESH' && taskDef.proxyConfiguration.properties && taskDef.proxyConfiguration.properties.length > 0) {
         taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
             if (!('value' in property)) {
                 arr[index].value = '';


### PR DESCRIPTION
This PR fix the Issue [197](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/197)

*Description of changes:*
This PR fixes the issue of Cannot read property 'length' of undefined. 

