### PR TITLE
fix: Container Definition Environment variables are being removed when empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,22 +129,7 @@ function removeIgnoredAttributes(taskDef) {
   return taskDef;
 }
 
-function maintainEnvironmentVariables(taskDef) {
-  if(taskDef && taskDef.containerDefinitions){
-    taskDef.containerDefinitions.forEach((container) => {
-      if(container.environment){
-        container.environment.forEach((property, index, arr) => {
-          if (!('value' in property)) {
-            arr[index].value = '';
-          }
-        });
-      }
-    });
-  }
-  return taskDef;
-}
-
-function maintainAppMeshConfiguration(taskDef) {
+function maintainValidObjects(taskDef) {
     if (validateProxyConfigurations(taskDef)) {
         taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
             if (!('value' in property)) {
@@ -154,6 +139,18 @@ function maintainAppMeshConfiguration(taskDef) {
                 arr[index].name = '';
             }
         });
+    }
+
+    if(taskDef && taskDef.containerDefinitions){
+      taskDef.containerDefinitions.forEach((container) => {
+        if(container.environment){
+          container.environment.forEach((property, index, arr) => {
+            if (!('value' in property)) {
+              arr[index].value = '';
+            }
+          });
+        }
+      });
     }
     return taskDef;
 }
@@ -268,7 +265,7 @@ async function run() {
       taskDefinitionFile :
       path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
     const fileContents = fs.readFileSync(taskDefPath, 'utf8');
-    const taskDefContents = maintainAppMeshConfiguration(removeIgnoredAttributes(maintainEnvironmentVariables(cleanNullKeys(yaml.parse(fileContents)))));
+    const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
     let registerResponse;
     try {
       registerResponse = await ecs.registerTaskDefinition(taskDefContents).promise();

--- a/index.js
+++ b/index.js
@@ -129,6 +129,21 @@ function removeIgnoredAttributes(taskDef) {
   return taskDef;
 }
 
+function maintainEnvironmentVariables(taskDef) {
+  if(taskDef && taskDef.containerDefinitions){
+    taskDef.containerDefinitions.forEach((container) => {
+      if(container.environment){
+        container.environment.forEach((property, index, arr) => {
+          if (!('value' in property)) {
+            arr[index].value = '';
+          }
+        });
+      }
+    });
+  }
+  return taskDef;
+}
+
 function maintainAppMeshConfiguration(taskDef) {
     if (validateProxyConfigurations(taskDef)) {
         taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
@@ -253,7 +268,7 @@ async function run() {
       taskDefinitionFile :
       path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
     const fileContents = fs.readFileSync(taskDefPath, 'utf8');
-    const taskDefContents = maintainAppMeshConfiguration(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
+    const taskDefContents = maintainAppMeshConfiguration(removeIgnoredAttributes(maintainEnvironmentVariables(cleanNullKeys(yaml.parse(fileContents)))));
     let registerResponse;
     try {
       registerResponse = await ecs.registerTaskDefinition(taskDefContents).promise();

--- a/index.test.js
+++ b/index.test.js
@@ -217,6 +217,10 @@ describe('Deploy to ECS', () => {
                         {
                             "name": "test",
                             "value": ""
+                        },
+                        {
+                            "name": "",
+                            "value": ""
                         }
                     ],
                     "secretOptions": [ {

--- a/index.test.js
+++ b/index.test.js
@@ -215,7 +215,7 @@ describe('Deploy to ECS', () => {
                             "value": "world"
                         },
                         {
-                            "name": "",
+                            "name": "test",
                             "value": ""
                         }
                     ],
@@ -245,6 +245,9 @@ describe('Deploy to ECS', () => {
                     environment: [{
                         name: 'hello',
                         value: 'world'
+                    }, {
+                        "name": "test",
+                        "value": ""
                     }]
                 }
             ],


### PR DESCRIPTION
This PR fix the issue #216  

The **cleanNullKeys** function removes all the null/undefined/empty parameters from the task def json which removes empty environment variables as well. After removing empty environment variables task def json looks something like following where value parameter is completely being omitted from the task def json - 

```
"environment": [
        {
          "name": "DEMO_VAR"
        },
        {
          "name": "APP_PLACEHOLDER_SERVICE",
          "value": "ecs-demo-site"
        },
        {
          "name": "APP_PLACEHOLDER_ENV",
          "value": "qa"
        },
        {
          "name": "APP_PLACEHOLDER_PORT",
          "value": "80"
        }
    ]
```

When GH action deploys this task def then ECS removes the complete object with no value field from the environment array of the task def which looks like following and causes deployment to fail in case that particular environment variable is the required one.

```
"environment": [
        {
          "name": "APP_PLACEHOLDER_SERVICE",
          "value": "ecs-demo-site"
        },
        {
          "name": "APP_PLACEHOLDER_ENV",
          "value": "qa"
        },
        {
          "name": "APP_PLACEHOLDER_PORT",
          "value": "80"
        }
    ]
```
 
In order to fix this issue I have implemented a function which commit loops through the environment array and restores any deleted values.