### PR TITLE
[TOOLS-3027] Identify remaining repos which should have github action for tracking velocity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,3 +14,27 @@ jobs:
       run: |
         npm ci
         npm test
+  # Upload Job and Workflow Metrics to Datadog
+  # https://app.datadoghq.com/dashboard/2gu-t9j-ppr
+  metrics:
+    needs: [check]
+    runs-on: ubuntu-latest
+    name: Datadog reports
+    if: ${{ always() }}
+    steps:
+      # CLEANUP TASK: https://scribdjira.atlassian.net/browse/TOOLS-2897
+      # Set up ruby for the metrics action
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # Report job and workflow performance metrics
+      - name: Job and Workflow performance reporting
+        uses: scribd/github-action-datadog-reporting@v1
+        with:
+          datadog-metric-prefix: 'github.action'
+          metrics-type: 'job_metrics'
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OCTOKIT_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,3 +69,28 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+  
+  # Upload Job and Workflow Metrics to Datadog
+  # https://app.datadoghq.com/dashboard/2gu-t9j-ppr
+  metrics:
+    needs: [analyze]
+    runs-on: ubuntu-latest
+    name: Datadog reports
+    if: ${{ always() }}
+    steps:
+      # CLEANUP TASK: https://scribdjira.atlassian.net/browse/TOOLS-2897
+      # Set up ruby for the metrics action
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # Report job and workflow performance metrics
+      - name: Job and Workflow performance reporting
+        uses: scribd/github-action-datadog-reporting@v1
+        with:
+          datadog-metric-prefix: 'github.action'
+          metrics-type: 'job_metrics'
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OCTOKIT_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,3 +25,28 @@ jobs:
         git add dist/
         git commit -m "chore: Update dist" || echo "No changes to commit"
         git push origin HEAD:master
+
+  # Upload Job and Workflow Metrics to Datadog
+  # https://app.datadoghq.com/dashboard/2gu-t9j-ppr
+  metrics:
+    needs: [check]
+    runs-on: ubuntu-latest
+    name: Datadog reports
+    if: ${{ always() }}
+    steps:
+      # CLEANUP TASK: https://scribdjira.atlassian.net/browse/TOOLS-2897
+      # Set up ruby for the metrics action
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # Report job and workflow performance metrics
+      - name: Job and Workflow performance reporting
+        uses: scribd/github-action-datadog-reporting@v1
+        with:
+          datadog-metric-prefix: 'github.action'
+          metrics-type: 'job_metrics'
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OCTOKIT_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}

--- a/.github/workflows/velocity_workflow.yml
+++ b/.github/workflows/velocity_workflow.yml
@@ -1,0 +1,43 @@
+# Upload Developer Velocity Metrics to Datadog
+# https://app.datadoghq.com/dashboard/2gu-t9j-ppr
+name: PR Velocity Workflow
+on:
+  pull_request:
+    types: [opened, closed]
+jobs:
+  metrics:
+    if: |
+      (github.event.action == 'closed' &&
+      github.event.pull_request.merged == true) ||
+      github.event.action == 'opened'
+    name: Track merge request activity
+    runs-on: ubuntu-latest
+    steps:
+      # CLEANUP TASK: https://scribdjira.atlassian.net/browse/TOOLS-2897
+      # Set up ruby for the action
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # CLEANUP TASK: https://scribdjira.atlassian.net/browse/TOOLS-2897
+      # Retrieve the teams for a user using GraphQL
+      - name: Get all teams for user
+        uses: tspascoal/get-user-teams-membership@v1
+        id: actor-teams
+        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
+        with:
+          username: ${{ github.event.pull_request.user.login }}
+          GITHUB_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}
+
+      # Report velocity metrics
+      - name: Reporting velocity metrics
+        id: datadog-metrics
+        uses: scribd/github-action-datadog-reporting@v1
+        with:
+          datadog-metric-prefix: 'github.action'
+          metrics-type: 'velocity'
+          teams: ${{ steps.actor-teams.outputs.teams }}
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OCTOKIT_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}


### PR DESCRIPTION
As a follow-up to TOOLS-3022, look for any major repository which is migrated to github and was missed in above ticket. Follow up with repo owners so the tracking action and workflow are added as part of migration to Github.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
