### PR TITLE
Add 'runtimePlatform' to list of ignored task definition attributes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const IGNORED_TASK_DEFINITION_ATTRIBUTES = [
   'status',
   'registeredAt',
   'deregisteredAt',
-  'registeredBy'
+  'registeredBy',
+  'runtimePlatform'
 ];
 
 // Deploy to a service that uses the 'ECS' deployment controller


### PR DESCRIPTION
#274 

Adds 'runtimePlatform' to list of ignored task definition attributes.
