### PR TITLE
fix: Strict Mode Deprecation

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,10 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - status-success=Run Unit Tests
+      - status-success=Semantic Pull Request
+
 pull_request_rules:
   - name: Automatically merge on CI success and review approval
     conditions:
@@ -13,10 +20,9 @@ pull_request_rules:
       - -closed
       - author!=dependabot[bot]
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
-        strict_method: merge
+        name: default
 
   - name: Automatically approve and merge Dependabot PRs
     conditions:
@@ -31,7 +37,6 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
-        strict_method: merge
+        name: default


### PR DESCRIPTION
Mergify deprecated strict mode in order to specify different conditions to get the PR in the queue and to get it merged. In order to solve this breaking change we will be changing mergify logic to have new queue_rules one as default for CI success and another for automated dependabot merges. Please follow the [link](https://blog.mergify.com/strict-mode-deprecation/) for more information.