### PR TITLE
fix: support new 'ECS' deployment type rather than relying on a null value

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ async function run() {
         throw new Error(`Service is ${serviceResponse.status}`);
       }
 
-      if (!serviceResponse.deploymentController || serviceResponse.deploymentController.type === "ECS") {
+      if (!serviceResponse.deploymentController || !serviceResponse.deploymentController.type || serviceResponse.deploymentController.type === 'ECS') {
         // Service uses the 'ECS' deployment controller, so we can call UpdateService
         await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment);
       } else if (serviceResponse.deploymentController.type === 'CODE_DEPLOY') {


### PR DESCRIPTION
Fixes #384.

Thanks @bradens for the fix! (original PR: #385)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.