### PR TITLE
feat: adds code for showing service event info when using ecs deploy controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The minimal permissions require access to CodeDeploy:
 
 This action emits debug logs to help troubleshoot deployment failures.  To see the debug logs, create a secret named `ACTIONS_STEP_DEBUG` with value `true` in your repository.
 
+The input `show-service-events` helps you to check logs from the service deployment events without going to the AWS console. This is just for the `ECS deployment controller`. Is desirable to configure [deployment circuit breaker](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html) to get a 'FAILED' rolloutState.
+
 ## License Summary
 
 This code is made available under the MIT license.

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   cluster:
     description: "The name of the ECS service's cluster.  Will default to the 'default' cluster"
     required: false
+  show-service-events:
+    description: "Whether to see or not the service deployment events when deployment rolloutState is 'FAILED'. Useful to see errors when a deployment fails."
+    required: false
+  show-service-events-frequency:
+    description: "The frequency for showing a log line of the service events (default: 15 seconds)."
+    required: false
   wait-for-service-stability:
     description: 'Whether to wait for the ECS service to reach stable state after deploying the new task definition. Valid value is "true". Will default to not waiting.'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "aws-actions-amazon-ecs-deploy-task-definition",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",


### PR DESCRIPTION

*Issue #, if available:* https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/447

*Description of changes:* 

- Added the new input show-service-events to enable the routine 
- The routine will call describe-ecs-service each for seconds to check how is the rolloutState of the deployment.
- If it is FAILED or IN_PROGRESS but with failedTasksCount more than 0, will detect that the deployment didn't go well, will show the latest 5th events and throw error. 
- If it is COMPLETED keep going.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
