### PR TITLE
fix: Use correct host for CodeDeploy

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
   }
   const createDeployResponse = await codedeploy.createDeployment(deploymentParams).promise();
   core.setOutput('codedeploy-deployment-id', createDeployResponse.deploymentId);
-  core.info(`Deployment started. Watch this deployment's progress in the AWS CodeDeploy console: https://console.aws.amazon.com/codesuite/codedeploy/deployments/${createDeployResponse.deploymentId}?region=${aws.config.region}`);
+  core.info(`Deployment started. Watch this deployment's progress in the AWS CodeDeploy console: https://${aws.config.region}.console.aws.amazon.com/codesuite/codedeploy/deployments/${createDeployResponse.deploymentId}`);
 
   // Wait for deployment to complete
   if (waitForService && waitForService.toLowerCase() === 'true') {

--- a/index.test.js
+++ b/index.test.js
@@ -532,7 +532,7 @@ describe('Deploy to ECS', () => {
         expect(mockEcsUpdateService).toHaveBeenCalledTimes(0);
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
 
-        expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the AWS CodeDeploy console: https://console.aws.amazon.com/codesuite/codedeploy/deployments/deployment-1?region=fake-region");
+        expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the AWS CodeDeploy console: https://fake-region.console.aws.amazon.com/codesuite/codedeploy/deployments/deployment-1");
     });
 
     test('registers the task definition contents and creates a CodeDeploy deployment, waits for 1 hour + deployment group\'s wait time', async () => {


### PR DESCRIPTION
## Description

* Perhaps due to an internal change in AWS, the region query string can no longer be used

※ It's not confirmed in all regions, but at least ap-northeast-1 seems to have this kind of specification

invalid url: `https://console.aws.amazon.com/codesuite/codedeploy/deployments/{id}?region={region}`
valid url: `https://{region}.console.aws.amazon.com/codesuite/codedeploy/deployments/{id}`



