### PR TITLE
feat: Add desired tasks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
     required: true
   desired-count:
     description: 'The number of instantiations of the task to place and keep running in your service.'
+    required: false
   service:
     description: 'The name of the ECS service to deploy to. The action will only register the task definition if no service is given.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ inputs:
   task-definition:
     description: 'The path to the ECS task definition file to register'
     required: true
+  desired-count:
+    description: 'The number of instantiations of the task to place and keep running in your service.'
   service:
     description: 'The name of the ECS service to deploy to. The action will only register the task definition if no service is given.'
     required: false

--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ async function run() {
     const forceNewDeployInput = core.getInput('force-new-deployment', { required: false }) || 'false';
     const forceNewDeployment = forceNewDeployInput.toLowerCase() === 'true';
 
-    let desiredCount = parseInt((core.getInput('desired-count', {required: false}))) || 1;
+    let desiredCount = parseInt((core.getInput('desired-count', {required: false}))) || 0;
 
 
     // Register the task definition

--- a/index.js
+++ b/index.js
@@ -269,7 +269,9 @@ async function run() {
 
     const forceNewDeployInput = core.getInput('force-new-deployment', { required: false }) || 'false';
     const forceNewDeployment = forceNewDeployInput.toLowerCase() === 'true';
-    const desiredCount = core.getInput('desired-count', {required: false})
+
+    let desiredCount = parseInt((core.getInput('desired-count', {required: false}))) || 1;
+
 
     // Register the task definition
     core.debug('Registering the task definition');
@@ -311,9 +313,9 @@ async function run() {
       }
 
       // Get Desired count of the service before deployment
-      const desiredCountResponse = describeResponse.desiredCount;
+      const desiredCountResponse = serviceResponse.desiredCount;
       if (desiredCountResponse === 0) {
-        throw new Error(`Service have desired-count ${desiredCountResponse}, set property 'desired-count' to \
+        core.warning(`Service have desired-count ${desiredCountResponse}, set property 'desired-count' to \
         start you service if required`);
       }
 

--- a/index.test.js
+++ b/index.test.js
@@ -162,6 +162,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -197,6 +198,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -887,7 +889,7 @@ describe('Deploy to ECS', () => {
         expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the AWS CodeDeploy console: https://console.aws.amazon.com/codesuite/codedeploy/deployments/deployment-1?region=fake-region");
     });
 
-     test('registers the task definition contents at an absolute path', async () => {
+    test('registers the task definition contents at an absolute path', async () => {
         core.getInput = jest.fn().mockReturnValueOnce('/hello/task-definition.json');
         fs.readFileSync.mockImplementation((pathInput, encoding) => {
             if (encoding != 'utf8') {
@@ -908,7 +910,7 @@ describe('Deploy to ECS', () => {
         expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
     });
 
-   test('waits for the service to be stable', async () => {
+    test('waits for the service to be stable', async () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
@@ -927,6 +929,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -961,6 +964,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -995,6 +999,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -1030,6 +1035,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: true
@@ -1053,6 +1059,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'default',
+            desiredCount: 1,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false

--- a/index.test.js
+++ b/index.test.js
@@ -162,7 +162,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -198,7 +198,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -685,7 +685,7 @@ describe('Deploy to ECS', () => {
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
     });
 
-    test.only('does not wait for a CodeDeploy deployment, parses JSON appspec file', async () => {
+    test('does not wait for a CodeDeploy deployment, parses JSON appspec file', async () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
@@ -694,6 +694,7 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('false')                // wait-for-service-stability
             .mockReturnValueOnce('')                     // wait-for-minutes
             .mockReturnValueOnce('')                     // force-new-deployment
+            .mockReturnValueOnce('')                     // desired count
             .mockReturnValueOnce('/hello/appspec.json')  // codedeploy-appspec
             .mockReturnValueOnce('MyApplication')        // codedeploy-application
             .mockReturnValueOnce('MyDeploymentGroup')    // codedeploy-deployment-group
@@ -914,9 +915,10 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('service-456')         // service
-            .mockReturnValueOnce('cluster-789')         // cluster
-            .mockReturnValueOnce('TRUE');               // wait-for-service-stability
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
+            .mockReturnValueOnce('');                    // desired count
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -929,7 +931,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -948,10 +950,11 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('service-456')         // service
-            .mockReturnValueOnce('cluster-789')         // cluster
-            .mockReturnValueOnce('TRUE')                // wait-for-service-stability
-            .mockReturnValueOnce('60');                     // wait-for-minutes
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
+            .mockReturnValueOnce('60')                   // wait-for-minutes
+            .mockReturnValueOnce('');                    // desired count
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -964,7 +967,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -983,10 +986,11 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('service-456')         // service
-            .mockReturnValueOnce('cluster-789')         // cluster
-            .mockReturnValueOnce('TRUE')                // wait-for-service-stability
-            .mockReturnValueOnce('1000');                   // wait-for-minutes
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
+            .mockReturnValueOnce('1000')                 // wait-for-minutes
+            .mockReturnValueOnce('');                    // desired count
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -999,7 +1003,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -1017,12 +1021,13 @@ describe('Deploy to ECS', () => {
     test('force new deployment', async () => {
         core.getInput = jest
             .fn()
-            .mockReturnValueOnce('task-definition.json')  // task-definition
+            .mockReturnValueOnce('task-definition.json') // task-definition
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('false')                // wait-for-service-stability
             .mockReturnValueOnce('')                     // wait-for-minutes
-            .mockReturnValueOnce('true');                  // force-new-deployment
+            .mockReturnValueOnce('true')                 // force-new-deployment
+            .mockReturnValueOnce('');                    // desired count
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1035,7 +1040,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: true
@@ -1046,7 +1051,8 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('service-456');         // service
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('');                    // desired count
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1059,7 +1065,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'default',
-            desiredCount: 1,
+            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false

--- a/index.test.js
+++ b/index.test.js
@@ -687,14 +687,14 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
-            .mockReturnValueOnce('service-456')         // service
-            .mockReturnValueOnce('cluster-789')         // cluster
-            .mockReturnValueOnce('false')               // wait-for-service-stability
-            .mockReturnValueOnce('')                    // wait-for-minutes
-            .mockReturnValueOnce('')                    // force-new-deployment
-            .mockReturnValueOnce('/hello/appspec.json') // codedeploy-appspec
-            .mockReturnValueOnce('MyApplication')       // codedeploy-application
-            .mockReturnValueOnce('MyDeploymentGroup');  // codedeploy-deployment-group
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('false')                // wait-for-service-stability
+            .mockReturnValueOnce('')                     // wait-for-minutes
+            .mockReturnValueOnce('')                     // force-new-deployment
+            .mockReturnValueOnce('/hello/appspec.json')  // codedeploy-appspec
+            .mockReturnValueOnce('MyApplication')        // codedeploy-application
+            .mockReturnValueOnce('MyDeploymentGroup')    // codedeploy-deployment-group
 
         fs.readFileSync.mockReturnValue(`
             {

--- a/index.test.js
+++ b/index.test.js
@@ -685,7 +685,7 @@ describe('Deploy to ECS', () => {
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
     });
 
-    test('does not wait for a CodeDeploy deployment, parses JSON appspec file', async () => {
+    test.only('does not wait for a CodeDeploy deployment, parses JSON appspec file', async () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
@@ -775,7 +775,7 @@ describe('Deploy to ECS', () => {
             services: ['service-456']
         });
 
-        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1, {
+        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1,{
             applicationName: 'MyApplication',
             deploymentGroupName: 'MyDeploymentGroup',
             revision: {

--- a/index.test.js
+++ b/index.test.js
@@ -162,7 +162,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -198,7 +197,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -931,7 +929,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -967,7 +964,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -990,7 +986,7 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
             .mockReturnValueOnce('1000')                 // wait-for-minutes
-            .mockReturnValueOnce('');                    // desired count
+            .mockReturnValueOnce('abc');                 // desired count is NaN
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1003,7 +999,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false
@@ -1027,7 +1022,7 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('false')                // wait-for-service-stability
             .mockReturnValueOnce('')                     // wait-for-minutes
             .mockReturnValueOnce('true')                 // force-new-deployment
-            .mockReturnValueOnce('');                    // desired count
+            .mockReturnValueOnce('4');                   // desired count is number
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1040,7 +1035,7 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            desiredCount: 0,
+            desiredCount: 4,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: true
@@ -1065,7 +1060,6 @@ describe('Deploy to ECS', () => {
         });
         expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
             cluster: 'default',
-            desiredCount: 0,
             service: 'service-456',
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false

--- a/index.test.js
+++ b/index.test.js
@@ -776,7 +776,7 @@ describe('Deploy to ECS', () => {
             services: ['service-456']
         });
 
-        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1,{
+        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1, {
             applicationName: 'MyApplication',
             deploymentGroupName: 'MyDeploymentGroup',
             revision: {


### PR DESCRIPTION
I would like to ask for help in the PR, as I can't fix 1 test which is failing.

*Issue #499*

*Add support for DesiredCount*
it would be great to have DesiredCount support during deployment.
https://docs.aws.amazon.com/cli/latest/reference/ecs/update-service.html
--desired-count


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.