### PR TITLE
feat: Allow setting codedeploy-config-name as input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   codedeploy-deployment-description:
     description: "A description of the deployment, if the ECS service uses the CODE_DEPLOY deployment controller."
     required: false
+  codedeploy-config-name:
+    description: "The deployment config name for the deployment, if the ECS service uses the CODE_DEPLOY deployment controller."
+    required: false
   force-new-deployment:
     description: 'Whether to force a new deployment of the service. Valid value is "true". Will default to not force a new deployment.'
     required: false

--- a/index.js
+++ b/index.js
@@ -183,7 +183,6 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
   let codeDeployDescription = core.getInput('codedeploy-deployment-description', { required: false });
 
   let codeDeployConfigName = core.getInput('codedeploy-config-name', { required: false });
-
   let deploymentGroupDetails = await codedeploy.getDeploymentGroup({
     applicationName: codeDeployApp,
     deploymentGroupName: codeDeployGroup

--- a/index.js
+++ b/index.js
@@ -182,6 +182,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 
   let codeDeployDescription = core.getInput('codedeploy-deployment-description', { required: false });
 
+  let codeDeployConfigName = core.getInput('codedeploy-config-name', { required: false });
+
   let deploymentGroupDetails = await codedeploy.getDeploymentGroup({
     applicationName: codeDeployApp,
     deploymentGroupName: codeDeployGroup
@@ -223,6 +225,9 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
   // If it hasn't been set then we don't even want to pass it to the api call to maintain previous behaviour.
   if (codeDeployDescription) {
     deploymentParams.description = codeDeployDescription
+  }
+  if (codeDeployConfigName) {
+    deploymentParams.deploymentConfigName = codeDeployConfigName
   }
   const createDeployResponse = await codedeploy.createDeployment(deploymentParams).promise();
   core.setOutput('codedeploy-deployment-id', createDeployResponse.deploymentId);

--- a/index.test.js
+++ b/index.test.js
@@ -804,7 +804,7 @@ describe('Deploy to ECS', () => {
         expect(mockEcsWaiter).toHaveBeenCalledTimes(0);
     });
 
-    test('registers the task definition contents and creates a CodeDeploy deployment with custom application, deployment group and description', async () => {
+    test('registers the task definition contents and creates a CodeDeploy deployment with custom application, deployment group, config name and description', async () => {
         core.getInput = jest
             .fn(input => {
                 return {
@@ -814,7 +814,8 @@ describe('Deploy to ECS', () => {
                     'wait-for-service-stability': 'TRUE',
                     'codedeploy-application': 'Custom-Application',
                     'codedeploy-deployment-group': 'Custom-Deployment-Group',
-                    'codedeploy-deployment-description': 'Custom-Deployment'
+                    'codedeploy-deployment-description': 'Custom-Deployment',
+                    'codedeploy-config-name': 'CodeDeployDefault.AllAtOnce'
                 }[input];
             });
 
@@ -848,6 +849,7 @@ describe('Deploy to ECS', () => {
             applicationName: 'Custom-Application',
             deploymentGroupName: 'Custom-Deployment-Group',
             description: 'Custom-Deployment',
+            deploymentConfigName: 'CodeDeployDefault.AllAtOnce',
             revision: {
                 revisionType: 'AppSpecContent',
                 appSpecContent: {


### PR DESCRIPTION
*Issue #479 , if available:*

*Description of changes:*

This allows the setting of the [config name](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html) of the deployment in Code Deploy via the `codedeploy-config-name` input variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
