### PR TITLE
docs: make description for "service" parameter less ambiguous.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'The number of instantiations of the task to place and keep running in your service.'
     required: false
   service:
-    description: 'The name of the ECS service to deploy to. The action will only register the task definition if no service is given.'
+    description: 'The name of the ECS service to deploy to. If no service is given, the action will not deploy the task, but only register the task definition.'
     required: false
   cluster:
     description: "The name of the ECS service's cluster.  Will default to the 'default' cluster"


### PR DESCRIPTION

The description for the "service" param states:
> "The name of the ECS service to deploy to. The action will only register the task definition if no service is given."

But in this case "only" is not meant as a condition, but as a limitation...
I stumbled upon this ambiguity in the documentation and it cost me an hour of my life, so I thought I might as well change it :-) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
