### PR TITLE
chore(ci): Upgrade github workflows to non-deprecated runtimes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: validate
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             // See https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c#file-conventional-commit-regex-md

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated the following actions to to their latest versions that use Nodejs20 and other updated dependencies. Following versions are using Nodejs 16 or older nodejs versions, this upgrade will switch them all to Node.js 20 (latest release of the respective actions).

* actions/github-scripts@v6 to v7
* github/codeql-action/init@v1 to v3
* github/codeql-action/autobuild@v1 to v3
* github/codeql-action/analyze@v1 to v3
For more information see:

* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

* https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
