### PR TITLE
Update test-workflow.yml

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -24,18 +24,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        
-    - name: Deploy Amazon ECS task definition with one-off task and wait for task stopped set to false
-      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
-      with:
-        task-definition: task-definition-run-task.json
-        cluster: github-actions-deploy-task-def-integ-test
-        run-task: true
-        run-task-subnets: subnet-e5604fce, subnet-fe9355b4, subnet-c49431bc, subnet-392f9b64
-        run-task-assign-public-IP: ENABLED
-        run-task-security-groups: sg-067ebcde49c0f3ad8
-        run-task-launch-type: FARGATE
-        wait-for-task-stopped: false
 
     - name: Deploy Amazon ECS task definition with one-off task and wait for task stopped set to true
       uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
@@ -56,3 +44,15 @@ jobs:
         service: github-actions-deploy-task-def-integ-test
         cluster: github-actions-deploy-task-def-integ-test
         wait-for-service-stability: true
+
+    - name: Deploy Amazon ECS task definition with one-off task and wait for task stopped set to false
+      uses: aws-actions/amazon-ecs-deploy-task-definition@abe77ebded86b685c231c58bd5936280c6fcc011
+      with:
+        task-definition: task-definition-run-task.json
+        cluster: github-actions-deploy-task-def-integ-test
+        run-task: true
+        run-task-subnets: subnet-e5604fce, subnet-fe9355b4, subnet-c49431bc, subnet-392f9b64
+        run-task-assign-public-IP: ENABLED
+        run-task-security-groups: sg-067ebcde49c0f3ad8
+        run-task-launch-type: FARGATE
+        wait-for-task-stopped: false


### PR DESCRIPTION
Changing order of integration tests being run, to prevent any stale cache response when calling `waitUntilTasksStopped` API multiple times.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
