### PR TITLE
chore: Update integ test workflows to reference v2 release tag

### DIFF
--- a/run_integ_test.sh
+++ b/run_integ_test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Update the integ test action workflow file with the commit ID to test
-sed -i "s|aws-actions/amazon-ecs-deploy-task-definition@v1|aws-actions/amazon-ecs-deploy-task-definition@$GIT_COMMIT_ID|g" test-workflow.yml
+sed -i "s|aws-actions/amazon-ecs-deploy-task-definition@v2|aws-actions/amazon-ecs-deploy-task-definition@$GIT_COMMIT_ID|g" test-workflow.yml
 sed -i "s|BUILD_ID|$CODEBUILD_BUILD_ID|g" test-workflow.yml
 
 mkdir -p .github/workflows

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -54,7 +54,7 @@ jobs:
         wait-for-task-stopped: true
 
     - name: Deploy Amazon ECS task definition with ECS Service
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
         task-definition: task-definition.json
         service: github-actions-deploy-task-def-integ-test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update integ test workflow to reference v2 release tag. There should be no change in behavior since the tag gets replaced by HEAD commit id when tests are run anyway. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
