### PR TITLE
chore: modified README.md file with permissions for one off task

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,32 +159,31 @@ Running a one-off/stand-alone task requires the following minimum set of permiss
  
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                "ecs:RunTask",
-                "ecs:RegisterTaskDefinition",
-                "ecs:DescribeTasks"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "PassRolesInTaskDefinition",
-            "Effect":"Allow",
-            "Action": [
-               "iam:PassRole"
-            ],
-            "Resource":[
-               "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
-               "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
-            ]
-         }
-    ]
+   "Version": "2012-10-17",
+   "Statement":[
+      {
+         "Sid": "VisualEditor0",
+         "Effect": "Allow",
+         "Action":[
+            "ecs:RunTask",
+            "ecs:RegisterTaskDefinition",
+            "ecs:DescribeTasks"
+         ],
+         "Resource": "*"
+      },
+      {
+         "Sid": "PassRolesInTaskDefinition",
+         "Effect":"Allow",
+         "Action":[
+            "iam:PassRole"
+         ],
+         "Resource":[
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
+         ]
+      }
+   ]
 }
- 
 ```
 Note: the policy above assumes the account has opted in to the ECS long ARN format.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Running a service requires the following minimum set of permissions:
 ```
  
 Running a one-off/stand-alone task requires the following minimum set of permissions:
- 
 ```json
 {
    "Version": "2012-10-17",

--- a/README.md
+++ b/README.md
@@ -116,9 +116,7 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 * [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
 ## Permissions
- 
 Running a service requires the following minimum set of permissions:
- 
 ```json
 {
    "Version":"2012-10-17",
@@ -164,7 +162,7 @@ Running a one-off/stand-alone task requires the following minimum set of permiss
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "RegisterTaskDefinition and runTask",
+            "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
                 "ecs:RunTask",
@@ -174,15 +172,15 @@ Running a one-off/stand-alone task requires the following minimum set of permiss
             "Resource": "*"
         },
         {
-         "Sid":"PassRolesInTaskDefinition",
-         "Effect":"Allow",
-         "Action":[
-            "iam:PassRole"
-         ],
-         "Resource":[
-            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
-            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
-         ]
+            "Sid": "PassRolesInTaskDefinition",
+            "Effect":"Allow",
+            "Action": [
+               "iam:PassRole"
+            ],
+            "Resource":[
+               "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
+               "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
+            ]
          }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/I
 * [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
 ## Permissions
-
-This action requires the following minimum set of permissions:
-
+ 
+Running a service requires the following minimum set of permissions:
+ 
 ```json
 {
    "Version":"2012-10-17",
@@ -156,7 +156,38 @@ This action requires the following minimum set of permissions:
    ]
 }
 ```
-
+ 
+Running a one-off/stand-alone task requires the following minimum set of permissions:
+ 
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "RegisterTaskDefinition and runTask",
+            "Effect": "Allow",
+            "Action": [
+                "ecs:RunTask",
+                "ecs:RegisterTaskDefinition",
+                "ecs:DescribeTasks"
+            ],
+            "Resource": "*"
+        },
+        {
+         "Sid":"PassRolesInTaskDefinition",
+         "Effect":"Allow",
+         "Action":[
+            "iam:PassRole"
+         ],
+         "Resource":[
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_role_name>",
+            "arn:aws:iam::<aws_account_id>:role/<task_definition_task_execution_role_name>"
+         ]
+         }
+    ]
+}
+ 
+```
 Note: the policy above assumes the account has opted in to the ECS long ARN format.
 
 ## AWS CodeDeploy Support


### PR DESCRIPTION
*Issue #, if available:*https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/608#issuecomment-2275957302

*Description of changes:* 
Added a section for permissions needed to run a one-off/stand-alone task 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
