### PR TITLE
fix: set networkConfiguration to null when using bridge network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Registers an Amazon ECS task definition and deploys it to an ECS service.
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
 In most cases when running a one-off task, subnet ID's, subnet groups, and assign public IP will be required. 
+Assign public IP will only be applied when a subnet or security group is defined. 
 
 ### Task definition file
 
@@ -269,7 +270,8 @@ In the following example, the service would not be updated until the ad-hoc task
         wait-for-task-stopped: true
 ```
 
-Overrides and VPC networking options are available as well. See [action.yml](action.yml) for more details.
+Overrides and VPC networking options are available as well. See [action.yml](action.yml) for more details. The `FARGATE` 
+launch type requires `awsvpc` network mode in your task definition and you must specify a network configuration.
 
 ## Troubleshooting
 

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ inputs:
     description: 'A comma-separated list of subnet IDs to assign to a task when run outside of a service. Will default to none.'
     required: false
   run-task-assign-public-IP:
-    description: "Whether the task's elastic network interface receives a public IP address. The default value is DISABLED."
+    description: "Whether the task's elastic network interface receives a public IP address. The default value is DISABLED but will only be applied if run-task-subnets or run-task-security-groups are also set."
     required: false
   run-task-launch-type:
     description: "ECS launch type for tasks run outside of a service. Valid values are 'FARGATE' or 'EC2'. Will default to 'FARGATE'."

--- a/dist/index.js
+++ b/dist/index.js
@@ -48,10 +48,10 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
     awsvpcConfiguration["securityGroups"] = securityGroupIds.split(',')
   }
 
-  if(assignPublicIP != ""){
+  if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  
+
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
     cluster: clusterName,
@@ -60,7 +60,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
       containerOverrides: containerOverrides
     },
     launchType: launchType,
-    networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? {} : { awsvpcConfiguration: awsvpcConfiguration }
+    networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? null : { awsvpcConfiguration: awsvpcConfiguration }
   });
 
   core.debug(`Run task response ${JSON.stringify(runTaskResponse)}`)

--- a/index.js
+++ b/index.js
@@ -42,10 +42,10 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
     awsvpcConfiguration["securityGroups"] = securityGroupIds.split(',')
   }
 
-  if(assignPublicIP != ""){
+  if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  
+
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
     cluster: clusterName,
@@ -54,7 +54,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes) {
       containerOverrides: containerOverrides
     },
     launchType: launchType,
-    networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? {} : { awsvpcConfiguration: awsvpcConfiguration }
+    networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? null : { awsvpcConfiguration: awsvpcConfiguration }
   });
 
   core.debug(`Run task response ${JSON.stringify(runTaskResponse)}`)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/616

*Description of changes:*
This PR sets networkConfiguration to null when neither subnetIds nor securityGroupIds are set. This fixes run task whenever launch type is EC2. I tested this branch with the github workflow I'm building and it works to run migrations as a task.

There was one failing test which I changed. I wonder whether this should only apply when the launchType is EC2 though? Let me know what you think

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
