### PR TITLE
(chore) Update actions/checkout to v4 for integ-tests

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Print current build ID
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As v2 is deprecated (node16; v4 use node20)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
