### PR TITLE
feat: add run-task-capacity-provider-strategy input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,11 @@ inputs:
   run-task-assign-public-IP:
     description: "Whether the task's elastic network interface receives a public IP address. The default value is DISABLED but will only be applied if run-task-subnets or run-task-security-groups are also set."
     required: false
+  run-task-capacity-provider-strategy:
+    description: 'A JSON array of capacity provider strategy items which should applied when running a task outside of a service. Will default to none.'
+    required: false
   run-task-launch-type:
-    description: "ECS launch type for tasks run outside of a service. Valid values are 'FARGATE' or 'EC2'. Will default to 'FARGATE'."
+    description: "ECS launch type for tasks run outside of a service. Valid values are 'FARGATE' or 'EC2'. Will default to 'FARGATE'. Will only be applied if run-task-capacity-provider-strategy is not set."
     required: false
   run-task-started-by:
     description: "A name to use for the startedBy tag when running a task outside of a service. Will default to 'GitHub-Actions'."

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,6 +38,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const containerOverrides = JSON.parse(core.getInput('run-task-container-overrides', { required: false }) || '[]');
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');
+  const capacityProviderStrategy = JSON.parse(core.getInput('run-task-capacity-provider-strategy', { required: false }) || '[]');
 
   let awsvpcConfiguration = {}
 
@@ -60,7 +61,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
     overrides: {
       containerOverrides: containerOverrides
     },
-    launchType: launchType,
+    capacityProviderStrategy: capacityProviderStrategy.length === 0 ? null : capacityProviderStrategy,
+    launchType: capacityProviderStrategy.length === 0 ? launchType : null,
     networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? null : { awsvpcConfiguration: awsvpcConfiguration },
     enableECSManagedTags: enableECSManagedTags,
     tags: tags

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const containerOverrides = JSON.parse(core.getInput('run-task-container-overrides', { required: false }) || '[]');
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');
+  const capacityProviderStrategy = JSON.parse(core.getInput('run-task-capacity-provider-strategy', { required: false }) || '[]');
 
   let awsvpcConfiguration = {}
 
@@ -54,7 +55,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
     overrides: {
       containerOverrides: containerOverrides
     },
-    launchType: launchType,
+    capacityProviderStrategy: capacityProviderStrategy.length === 0 ? null : capacityProviderStrategy,
+    launchType: capacityProviderStrategy.length === 0 ? launchType : null,
     networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? null : { awsvpcConfiguration: awsvpcConfiguration },
     enableECSManagedTags: enableECSManagedTags,
     tags: tags


### PR DESCRIPTION
When you use cluster auto scaling, you must specify `capacityProviderStrategy` and not `launchType` (as mentioned in the [RunTask](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy) documentation). Unfortunately this is currently not possible to configure when running a one-off task with this action.

*Issue #, if available:*

None

*Description of changes:*

This adds a new input `run-task-capacity-provider-strategy` which takes a JSON array of capacity provider strategy items. When this is specified, `run-task-launch-type` will not be applied.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
