### PR TITLE
test: run integ tests upon pull request approval

### DIFF
--- a/.github/workflows/pr-approval.yml
+++ b/.github/workflows/pr-approval.yml
@@ -1,0 +1,15 @@
+name: PR Approval
+
+on:
+    pull_request_review:
+        types: [submitted]
+    workflow_dispatch:
+jobs:
+  integ_tests:
+      if: github.event.review.state == 'approved'
+      name: Run Integration Tests
+      uses: aws-actions/amazon-ecs-deploy-task-definition/.github/workflows/test-workflow.yml@integ-tests
+      with:
+        call_local_action: 'true'
+      secrets:
+        account_id: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,6 +5,7 @@ queue_rules:
       - status-success=Run Unit Tests
       - status-success=Semantic Pull Request
       - status-success=Analyze (javascript)
+      - status-success=Run Integration Tests
 
 pull_request_rules:
   - name: Automatically merge on CI success and review approval
@@ -16,6 +17,7 @@ pull_request_rules:
       - status-success=Run Unit Tests
       - status-success=Semantic Pull Request
       - status-success=Analyze (javascript)
+      - status-success=Run Integration Tests
       - label!=work-in-progress
       - -title~=(WIP|wip)
       - -merged

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,32 @@
+{
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "sh",
+        "-c"
+      ],
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": [
+        "/bin/sh -c \"echo '<html> <head> <title>Amazon ECS Sample App</title> <style>body {margin-top: 40px; background-color: #333;} </style> </head><body> <div style=color:white;text-align:center> <h1>Amazon ECS Sample App</h1> <h2>Congratulations!</h2> <p>Your application is now running on a container in Amazon ECS.</p> </div></body></html>' >  /usr/local/apache2/htdocs/index.html && httpd-foreground\""
+      ],
+      "cpu": 256,
+      "memoryReservation": 512,
+      "image": "httpd:2.4",
+      "essential": true,
+      "name": "sample-app"
+    }
+  ],
+  "memory": "512",
+  "family": "github-actions-deploy-task-def-integ-tests",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "cpu": "256"
+}


### PR DESCRIPTION
## Description of changes

Run integration tests upon pull request approval.

## Testing

Testing was done in a [fork of this repository](https://github.com/dani-chmb/amazon-ecs-deploy-task-definition).
 
- [The `integ-tests` branch of this fork](https://github.com/dani-chmb/amazon-ecs-deploy-task-definition/blob/integ-tests/.github/workflows/test-workflow.yml) was simplified to only run a single integration test. 
- [A mock pull-request](https://github.com/dani-chmb/amazon-ecs-deploy-task-definition/pull/1) was created and approved to verify automatic execution of integration tests.
- `mergify.yml` changes were not included in the fork.

### Test Images

1. Mock PR prior to review.

![preapproval](https://github.com/user-attachments/assets/26f31f9a-5873-4f10-897e-f0fa7de8c7e7)

2. Mock PR after a review without approval.

![non-approved-review](https://github.com/user-attachments/assets/f9dae799-fe70-403b-a3a3-77d4b99d85fb)

3. Mock PR after an approving review.

![post-approval](https://github.com/user-attachments/assets/a84c411e-251d-4129-ab81-09234530b0ff)



## Related PRs
 
PR 2/2 for running integration tests upon pull-request approval. [See other PR for `integ-tests` branch](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/666).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
