### PR TITLE
fix: ignore enableFaultInjection parameter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -23,7 +23,8 @@ const IGNORED_TASK_DEFINITION_ATTRIBUTES = [
   'status',
   'registeredAt',
   'deregisteredAt',
-  'registeredBy'
+  'registeredBy',
+  'enableFaultInjection'
 ];
 
 // Method to run a stand-alone task with desired inputs

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const IGNORED_TASK_DEFINITION_ATTRIBUTES = [
   'status',
   'registeredAt',
   'deregisteredAt',
-  'registeredBy'
+  'registeredBy',
+  'enableFaultInjection'
 ];
 
 // Method to run a stand-alone task with desired inputs

--- a/index.test.js
+++ b/index.test.js
@@ -304,6 +304,7 @@ describe('Deploy to ECS', () => {
                 } ],
                 "requiresCompatibilities": [ "EC2" ],
                 "registeredAt": 1611690781,
+                "enableFaultInjection": false,
                 "family": "task-def-family"
             }
             `;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Same motivation as other ignored parameters. We have recently got couple of failed pipelines because the field started to appear on the task definitions returned by AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
