### PR TITLE
fix: use propagateTags service value

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ inputs:
     description: "Determines whether to turn on Amazon ECS managed tags 'aws:ecs:serviceName' and 'aws:ecs:clusterName' for the tasks in the service."
     required: false
   propagate-tags:
-    description: "Determines to propagate the tags from the 'SERVICE' to the task. Will default to 'NONE'."
+    description: "Determines to propagate the tags from the 'SERVICE' to the task."
     required: false
 outputs:
   task-definition-arn:

--- a/index.js
+++ b/index.js
@@ -480,7 +480,11 @@ async function run() {
     if (enableECSManagedTagsInput !== '') {
       enableECSManagedTags = enableECSManagedTagsInput.toLowerCase() === 'true';
     }
-    const propagateTags = core.getInput('propagate-tags', { required: false }) || 'NONE';
+    const propagateTagsInput = core.getInput('propagate-tags', { required: false }) || '';
+    let propagateTags = null;
+    if (propagateTagsInput !== '') {
+      propagateTags = propagateTagsInput;
+    }
 
     // Register the task definition
     core.debug('Registering the task definition');

--- a/index.test.js
+++ b/index.test.js
@@ -96,7 +96,7 @@ describe('Deploy to ECS', () => {
             () => Promise.resolve({
                 failures: [],
                 services: [{ 
-                    status: 'ACTIVE' 
+                    status: 'ACTIVE'
                 }]
             })
         );
@@ -187,7 +187,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenCalledTimes(0);
@@ -221,7 +221,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenCalledTimes(0);
@@ -957,7 +957,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
@@ -999,7 +999,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
@@ -1041,7 +1041,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
@@ -1085,7 +1085,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: true,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
     });
@@ -1112,7 +1112,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
     });
@@ -1287,7 +1287,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
         expect(mockRunTask).toHaveBeenCalledWith({
@@ -1634,7 +1634,7 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('')                     // force-new-deployment
             .mockReturnValueOnce('')                     // desired-count
             .mockReturnValueOnce('true')                 // enable-ecs-managed-tags
-            .mockReturnValueOnce('SERVICE');             // propagate-tags      
+            .mockReturnValueOnce('SERVICE');             // propagate-tags
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1667,7 +1667,7 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('')                     // force-new-deployment
             .mockReturnValueOnce('')                     // desired-count
             .mockReturnValueOnce('false')                // enable-ecs-managed-tags
-            .mockReturnValueOnce('SERVICE');             // propagate-tags      
+            .mockReturnValueOnce('SERVICE');             // propagate-tags
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1718,7 +1718,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: [{
                 name: 'ebs1',
                 managedEBSVolume: {
@@ -1783,7 +1783,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: [{
                 name: 'ebs1',
                 managedEBSVolume: {
@@ -1845,7 +1845,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: [{
                 name: 'ebs1',
                 managedEBSVolume: {
@@ -1864,7 +1864,7 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE',
+            propagateTags: null,
             volumeConfigurations: []
         });
     });


### PR DESCRIPTION
Closes: #707 

Without this PR, if propagate-tags is set to `null` if user don't set it.
This overwrite the service propagateTags and this is a problem when it's set to SERVICE or TASK_DEFINITION (in IaC typically).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
