### PR TITLE
chore: Replace quotes when sanitizing title

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -39,6 +39,7 @@ jobs:
             // Escape special characters for Slack
             const escapeForSlack = (text) => {
               return text
+                .replace(/"/g, '&quot;')
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')
                 .replace(/[@]/g, '\\@')


### PR DESCRIPTION
- Before sending notification to Slack, replace any quotes that exist in Github entity title


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
