### PR TITLE
feat: Add support for 'VolumeConfigurations' property on both UpdateService and RunTask API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,41 @@ You can propagate your custom tags from your existing service using `propagate-t
           propagate-tags: SERVICE
 ```
 
+### EBS Volume Configuration
+This action supports configuring Amazon EBS volumes for both services and standalone tasks.
+
+For Services (Update Service):
+
+```yaml
+    - name: Deploy to Amazon ECS with EBS Volume
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition: task-definition.json
+        service: my-service
+        cluster: my-cluster
+        wait-for-service-stability: true
+        service-managed-ebs-volume-name: "ebs1"
+        service-managed-ebs-volume: '{"sizeInGiB": 30, "volumeType": "gp3", "encrypted": true, "roleArn":"arn:aws:iam::<account-id>:role/ebs-role"}'
+```
+
+Note: Note: Your task definition must include a volume that is configuredAtLaunch:
+
+
+
+For Standalone Tasks (RunTask):
+
+```yaml
+    - name: Deploy to Amazon ECS
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition: task-definition.json
+        cluster: my-cluster
+        run-task: true
+        run-task-launch-type: EC2
+        run-task-managed-ebs-volume-name: "ebs1"
+        run-task-managed-ebs-volume: '{"filesystemType":"xfs", "roleArn":"arn:aws:iam::<account-id>:role/github-actions-setup-stack-EBSRole-YwVmgS4g7gQE", "encrypted":false, "sizeInGiB":30}'
+```
+
 ## Credentials and Region
 
 This action relies on the [default behavior of the AWS SDK for Javascript](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) to determine AWS credentials and region.

--- a/README.md
+++ b/README.md
@@ -149,9 +149,18 @@ For Services (Update Service):
         service-managed-ebs-volume: '{"sizeInGiB": 30, "volumeType": "gp3", "encrypted": true, "roleArn":"arn:aws:iam::<account-id>:role/ebs-role"}'
 ```
 
-Note: Note: Your task definition must include a volume that is configuredAtLaunch:
+Note: Your task definition must include a volume that is configuredAtLaunch:
 
-
+```json
+    ...
+    "volumes": [
+        {
+            "name": "ebs1",
+            "configuredAtLaunch": true
+        }
+    ],
+    ...
+```
 
 For Standalone Tasks (RunTask):
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,15 @@ inputs:
   force-new-deployment:
     description: 'Whether to force a new deployment of the service. Valid value is "true". Will default to not force a new deployment.'
     required: false
+  service-managed-ebs-volume-name:
+    description: "The name of the volume to manage in the ECS service."
+    required: false
+  service-managed-ebs-volume:
+    description: "A JSON object that defines the configuration for the Amazon EBS volume that Amazon ECS creates and 
+                  manages on your behalf. These settings are used to create each Amazon EBS volume, with one volume created for 
+                  each task in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console once they 
+                  are created."
+    required: false
   run-task:
     description: 'A boolean indicating whether to run a stand-alone task in a ECS cluster. Task will run before the service is updated if both are provided. Default value is false .'
     required: false
@@ -66,6 +75,15 @@ inputs:
     required: false
   run-task-tags:
     description: 'A JSON array of tags.'
+    required: false
+  run-task-managed-ebs-volume-name:
+    description: "The name of the volume to manage in the ECS service."
+    required: false
+  run-task-managed-ebs-volume:
+    description: "A JSON object that defines the configuration for the Amazon EBS volume that Amazon ECS creates and 
+                  manages on your behalf. These settings are used to create each Amazon EBS volume, with one volume created for 
+                  each task in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console once they 
+                  are created."
     required: false
   wait-for-task-stopped:
     description: 'Whether to wait for the task to stop when running it outside of a service. Will default to not wait.'

--- a/action.yml
+++ b/action.yml
@@ -41,13 +41,10 @@ inputs:
     description: 'Whether to force a new deployment of the service. Valid value is "true". Will default to not force a new deployment.'
     required: false
   service-managed-ebs-volume-name:
-    description: "The name of the volume to manage in the ECS service."
+    description: "The name of the volume, to be manage in the ECS service. This value must match the volume name from the Volume object in the task definition, that was configuredAtLaunch."
     required: false
   service-managed-ebs-volume:
-    description: "A JSON object that defines the configuration for the Amazon EBS volume that Amazon ECS creates and 
-                  manages on your behalf. These settings are used to create each Amazon EBS volume, with one volume created for 
-                  each task in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console once they 
-                  are created."
+    description: "A JSON object defining the configuration settings for the EBS Service volume that was ConfiguredAtLaunch. You can configure size, volumeType, IOPS, throughput, snapshot and encryption in ServiceManagedEBSVolumeConfiguration. Currently, the only supported volume type is an Amazon EBS volume."
     required: false
   run-task:
     description: 'A boolean indicating whether to run a stand-alone task in a ECS cluster. Task will run before the service is updated if both are provided. Default value is false .'
@@ -77,13 +74,10 @@ inputs:
     description: 'A JSON array of tags.'
     required: false
   run-task-managed-ebs-volume-name:
-    description: "The name of the volume to manage in the ECS service."
+    description: "The name of the volume. This value must match the volume name from the Volume object in the task definition, that was configuredAtLaunch."
     required: false
   run-task-managed-ebs-volume:
-    description: "A JSON object that defines the configuration for the Amazon EBS volume that Amazon ECS creates and 
-                  manages on your behalf. These settings are used to create each Amazon EBS volume, with one volume created for 
-                  each task in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console once they 
-                  are created."
+    description: "A JSON object defining the configuration settings for the Amazon EBS task volume that was configuredAtLaunch. These settings are used to create each Amazon EBS volume, with one volume created for each task in the service. The Amazon EBS volumes are visible in your account in the Amazon EC2 console once they are created."
     required: false
   wait-for-task-stopped:
     description: 'Whether to wait for the task to stop when running it outside of a service. Will default to not wait.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,6 +39,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');
   const capacityProviderStrategy = JSON.parse(core.getInput('run-task-capacity-provider-strategy', { required: false }) || '[]');
+  const runTaskManagedEBSVolumeName = core.getInput('run-task-managed-ebs-volume', { required: false }) || '';
+  const runTaskManagedEBSVolume = core.getInput('run-task-managed-ebs-volume-name', { required: false }) || '{}';
 
   let awsvpcConfiguration = {}
 
@@ -53,6 +55,21 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
+  let volumeConfigurations = []
+  let volumeConfigurationJSON = {}
+
+  if (runTaskManagedEBSVolumeName != '') {
+    if (runTaskManagedEBSVolume != '{}') {
+      taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEbsVolume);
+      volumeConfigurationJSON["name"] = runTaskManagedEbsVolumeName;
+      volumeConfigurationJSON["managedEBSVolume"] = taskManagedEbsVolumeObject;
+      volumeConfigurations.push(volumeConfigurationJSON);
+    } else {
+      core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. Ignoring run-task-managed-ebs-volume property`);
+    }
+  } else {
+    core.info(`No VolumeConfiguration Property provided for run-task-managed-ebs-volume`);
+  }
 
   const runTaskResponse = await ecs.runTask({
     startedBy: startedBy,
@@ -65,7 +82,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
     launchType: capacityProviderStrategy.length === 0 ? launchType : null,
     networkConfiguration: Object.keys(awsvpcConfiguration).length === 0 ? null : { awsvpcConfiguration: awsvpcConfiguration },
     enableECSManagedTags: enableECSManagedTags,
-    tags: tags
+    tags: tags,
+    volumeConfigurations: volumeConfigurations
   });
 
   core.debug(`Run task response ${JSON.stringify(runTaskResponse)}`)
@@ -90,6 +108,46 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   } else {
     core.debug('Not waiting for the task to stop');
   }
+}
+
+async function convertToManagedEbsVolumeObject(managedEbsVolume) {
+  managedEbsVolumeObject = {}
+  const ebsVolumeObject = JSON.parse(managedEbsVolume);
+  if ('roleArn' in ebsVolumeObject){ // required property
+    managedEbsVolumeObject['roleArn'] = ebsVolumeObject['roleArn'];
+    core.debug(`Found RoleArn ${ebsVolumeObject['roleArn']}`);
+  } else {
+    throw new Error('managed-ebs-volume must provide "role-arn" to associate with the EBS volume')
+  }
+
+  if ('encrypted' in ebsVolumeObject) {
+    managedEbsVolumeObject['encrypted'] = ebsVolumeObject.encrypted;
+  }
+  if ('filesystemType' in ebsVolumeObject) {
+    managedEbsVolumeObject['filesystemType'] = ebsVolumeObject.filesystemType;
+  }
+  if ('iops' in ebsVolumeObject) {
+    managedEbsVolumeObject['iops'] = ebsVolumeObject.iops;
+  }
+  if ('kmsKeyId' in ebsVolumeObject) {
+    managedEbsVolumeObject['kmsKeyId'] = ebsVolumeObject.kmsKeyId;
+  }
+  if ('sizeInGiB' in ebsVolumeObject) {
+    managedEbsVolumeObject['sizeInGiB'] = ebsVolumeObject.sizeInGiB;
+  }
+  if ('snapshotId' in ebsVolumeObject) {
+    managedEbsVolumeObject['snapshotId'] = ebsVolumeObject.snapshotId;
+  }
+  if ('tagSpecifications' in ebsVolumeObject) {
+    managedEbsVolumeObject['tagSpecifications'] = ebsVolumeObject.tagSpecifications;
+  }
+  if (('throughput' in ebsVolumeObject) && (('volumeType' in ebsVolumeObject) && (ebsVolumeObject.volumeType == 'gp3'))){
+    managedEbsVolumeObject["throughput"] = ebsVolumeObject.throughput;
+  }
+  if ('volumeType' in ebsVolumeObject) {
+    managedEbsVolumeObject['volumeType'] = ebsVolumeObject.volumeType;
+  }
+  return managedEbsVolumeObject;
 }
 
 // Poll tasks until they enter a stopped state
@@ -140,7 +198,38 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 
 // Deploy to a service that uses the 'ECS' deployment controller
 async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags) {
-  core.debug('Updating the service');
+  core.debug('Updating the provided ECS service');
+
+  const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
+  core.debug('serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}');
+  core.debug('serviceManagedEbsVolume Name.');
+  const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
+  core.debug('serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}');
+  core.debug('serviceManagedEbsVolume Value.');
+
+  core.debug('Updating the service contd..');
+
+  let volumeConfigurations = []
+  let volumeConfigurationJSON = {}
+
+  if (serviceManagedEbsVolumeName != '') {
+    core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
+    core.debug('Assigning VolumeConfiguration.');
+    if (serviceManagedEbsVolume != '{}') {
+      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      volumeConfigurationJSON["name"] = serviceManagedEbsVolumeName;
+      volumeConfigurationJSON["managedEBSVolume"] = serviceManagedEbsVolumeObject;
+      volumeConfigurations.push(volumeConfigurationJSON);
+      core.debug('Assigning VolumeConfiguration Object');
+    } else {
+      core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
+    }
+  }  else {
+    core.debug('No VolumeConfiguration Property provided for service-managed-ebs-volume');
+  }
+  core.debug('VolumeConfiguration Value: ${volumeConfiguration}');
+  core.debug('VolumeConfiguration Value Set.');
+
 
   let params = {
     cluster: clusterName,
@@ -148,7 +237,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     taskDefinition: taskDefArn,
     forceNewDeployment: forceNewDeployment,
     enableECSManagedTags: enableECSManagedTags,
-    propagateTags: propagateTags
+    propagateTags: propagateTags,
+    volumeConfigurations: volumeConfigurations
   };
 
   // Add the desiredCount property only if it is defined and a number.
@@ -249,9 +339,9 @@ function removeIgnoredAttributes(taskDef) {
   for (var attribute of IGNORED_TASK_DEFINITION_ATTRIBUTES) {
     if (taskDef[attribute]) {
       core.warning(`Ignoring property '${attribute}' in the task definition file. ` +
-        'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
-        'but it is not a valid field when registering a new task definition. ' +
-        'This field can be safely removed from your task definition file.');
+          'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
+          'but it is not a valid field when registering a new task definition. ' +
+          'This field can be safely removed from your task definition file.');
       delete taskDef[attribute];
     }
   }
@@ -260,29 +350,29 @@ function removeIgnoredAttributes(taskDef) {
 }
 
 function maintainValidObjects(taskDef) {
-    if (validateProxyConfigurations(taskDef)) {
-        taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
-            if (!('value' in property)) {
-                arr[index].value = '';
-            }
-            if (!('name' in property)) {
-                arr[index].name = '';
-            }
-        });
-    }
+  if (validateProxyConfigurations(taskDef)) {
+    taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
+      if (!('value' in property)) {
+        arr[index].value = '';
+      }
+      if (!('name' in property)) {
+        arr[index].name = '';
+      }
+    });
+  }
 
-    if(taskDef && taskDef.containerDefinitions){
-      taskDef.containerDefinitions.forEach((container) => {
-        if(container.environment){
-          container.environment.forEach((property, index, arr) => {
-            if (!('value' in property)) {
-              arr[index].value = '';
-            }
-          });
-        }
-      });
-    }
-    return taskDef;
+  if(taskDef && taskDef.containerDefinitions){
+    taskDef.containerDefinitions.forEach((container) => {
+      if(container.environment){
+        container.environment.forEach((property, index, arr) => {
+          if (!('value' in property)) {
+            arr[index].value = '';
+          }
+        });
+      }
+    });
+  }
+  return taskDef;
 }
 
 function validateProxyConfigurations(taskDef){
@@ -314,8 +404,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 
   // Insert the task def ARN into the appspec file
   const appSpecPath = path.isAbsolute(codeDeployAppSpecFile) ?
-    codeDeployAppSpecFile :
-    path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
+      codeDeployAppSpecFile :
+      path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
   const fileContents = fs.readFileSync(appSpecPath, 'utf8');
   const appSpecContents = yaml.parse(fileContents);
 
@@ -414,8 +504,8 @@ async function run() {
     // Register the task definition
     core.debug('Registering the task definition');
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-      taskDefinitionFile :
-      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+        taskDefinitionFile :
+        path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
     const fileContents = fs.readFileSync(taskDefPath, 'utf8');
     const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
     let registerResponse;
@@ -484,7 +574,7 @@ module.exports = run;
 
 /* istanbul ignore next */
 if (require.main === require.cache[eval('__filename')]) {
-    run();
+  run();
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,7 +55,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  let volumeConfigurations = null;
+  let volumeConfigurations = [];
   let taskManagedEBSVolumeObject;
 
   if (runTaskManagedEBSVolumeName != '') {
@@ -203,7 +203,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
   const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
-  let volumeConfigurations = null;
+  let volumeConfigurations = [];
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEBSVolumeName != '') {
@@ -224,16 +224,13 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     taskDefinition: taskDefArn,
     forceNewDeployment: forceNewDeployment,
     enableECSManagedTags: enableECSManagedTags,
-    propagateTags: propagateTags
+    propagateTags: propagateTags,
+    volumeConfigurations: volumeConfigurations
   };
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
-  }
-  // Add VolumeConfigurations property only it is not null
-  if(volumeConfigurations !== null){
-    params.volumeConfigurations = volumeConfigurations;
   }
   await ecs.updateService(params);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -114,39 +114,40 @@ async function convertToManagedEbsVolumeObject(managedEbsVolume) {
   managedEbsVolumeObject = {}
   const ebsVolumeObject = JSON.parse(managedEbsVolume);
   if ('roleArn' in ebsVolumeObject){ // required property
-    managedEbsVolumeObject['roleArn'] = ebsVolumeObject['roleArn'];
+    managedEbsVolumeObject.roleArn = ebsVolumeObject.roleArn;
     core.debug(`Found RoleArn ${ebsVolumeObject['roleArn']}`);
   } else {
     throw new Error('managed-ebs-volume must provide "role-arn" to associate with the EBS volume')
   }
 
   if ('encrypted' in ebsVolumeObject) {
-    managedEbsVolumeObject['encrypted'] = ebsVolumeObject.encrypted;
+    managedEbsVolumeObject.encrypted = ebsVolumeObject.encrypted;
   }
   if ('filesystemType' in ebsVolumeObject) {
-    managedEbsVolumeObject['filesystemType'] = ebsVolumeObject.filesystemType;
+    managedEbsVolumeObject.filesystemType = ebsVolumeObject.filesystemType;
   }
   if ('iops' in ebsVolumeObject) {
-    managedEbsVolumeObject['iops'] = ebsVolumeObject.iops;
+    managedEbsVolumeObject.iops = ebsVolumeObject.iops;
   }
   if ('kmsKeyId' in ebsVolumeObject) {
-    managedEbsVolumeObject['kmsKeyId'] = ebsVolumeObject.kmsKeyId;
+    managedEbsVolumeObject.kmsKeyId = ebsVolumeObject.kmsKeyId;
   }
   if ('sizeInGiB' in ebsVolumeObject) {
-    managedEbsVolumeObject['sizeInGiB'] = ebsVolumeObject.sizeInGiB;
+    managedEbsVolumeObject.sizeInGiB = ebsVolumeObject.sizeInGiB;
   }
   if ('snapshotId' in ebsVolumeObject) {
-    managedEbsVolumeObject['snapshotId'] = ebsVolumeObject.snapshotId;
+    managedEbsVolumeObject.snapshotId = ebsVolumeObject.snapshotId;
   }
   if ('tagSpecifications' in ebsVolumeObject) {
-    managedEbsVolumeObject['tagSpecifications'] = ebsVolumeObject.tagSpecifications;
+    managedEbsVolumeObject.tagSpecifications = ebsVolumeObject.tagSpecifications;
   }
   if (('throughput' in ebsVolumeObject) && (('volumeType' in ebsVolumeObject) && (ebsVolumeObject.volumeType == 'gp3'))){
-    managedEbsVolumeObject["throughput"] = ebsVolumeObject.throughput;
+    managedEbsVolumeObject.throughput = ebsVolumeObject.throughput;
   }
   if ('volumeType' in ebsVolumeObject) {
-    managedEbsVolumeObject['volumeType'] = ebsVolumeObject.volumeType;
+    managedEbsVolumeObject.volumeType = ebsVolumeObject.volumeType;
   }
+  core.debug(`Created managedEbsVolumeObject: ${JSON.stringify(managedEbsVolumeObject)}`);
   return managedEbsVolumeObject;
 }
 
@@ -201,16 +202,17 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   core.debug('Updating the provided ECS service');
 
   const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
-  core.debug('serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}');
+  core.debug(`serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}`);
   core.debug('serviceManagedEbsVolume Name.');
   const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
-  core.debug('serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}');
+  core.debug(`serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}`);
   core.debug('serviceManagedEbsVolume Value.');
 
   core.debug('Updating the service contd..');
 
   let volumeConfigurations = []
   let volumeConfigurationJSON = {}
+  let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEbsVolumeName != '') {
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -224,13 +224,16 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     taskDefinition: taskDefArn,
     forceNewDeployment: forceNewDeployment,
     enableECSManagedTags: enableECSManagedTags,
-    propagateTags: propagateTags,
-    volumeConfigurations: volumeConfigurations
+    propagateTags: propagateTags
   };
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
+  }
+  // Add VolumeConfigurations property only it is not null
+  if(volumeConfigurations !== null){
+    params.volumeConfigurations = volumeConfigurations;
   }
   await ecs.updateService(params);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   }
 }
 
-async function convertToManagedEbsVolumeObject(managedEbsVolume) {
+function convertToManagedEbsVolumeObject(managedEbsVolume) {
   managedEbsVolumeObject = {}
   const ebsVolumeObject = JSON.parse(managedEbsVolume);
   if ('roleArn' in ebsVolumeObject){ // required property
@@ -217,8 +217,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = await convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
-      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(ebsVolumeObject)}`);
+      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(serviceManagedEbsVolumeObject)}`);
 
       volumeConfigurations = [{
         name: serviceManagedEbsVolumeName,

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,8 +39,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');
   const capacityProviderStrategy = JSON.parse(core.getInput('run-task-capacity-provider-strategy', { required: false }) || '[]');
-  const runTaskManagedEBSVolumeName = core.getInput('run-task-managed-ebs-volume', { required: false }) || '';
-  const runTaskManagedEBSVolume = core.getInput('run-task-managed-ebs-volume-name', { required: false }) || '{}';
+  const runTaskManagedEBSVolumeName = core.getInput('run-task-managed-ebs-volume-name', { required: false }) || '';
+  const runTaskManagedEBSVolume = core.getInput('run-task-managed-ebs-volume', { required: false }) || '{}';
 
   let awsvpcConfiguration = {}
 
@@ -60,7 +60,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
 
   if (runTaskManagedEBSVolumeName != '') {
     if (runTaskManagedEBSVolume != '{}') {
-      taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEbsVolume);
+      taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEBSVolume);
       volumeConfigurations = [{
             name: runTaskManagedEBSVolumeName,
             managedEBSVolume: taskManagedEBSVolumeObject
@@ -200,18 +200,18 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags) {
   core.debug('Updating the service');
 
-  const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
-  const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
+  const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
+  const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
   let volumeConfigurations;
   let serviceManagedEbsVolumeObject;
 
-  if (serviceManagedEbsVolumeName != '') {
-    if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+  if (serviceManagedEBSVolumeName != '') {
+    if (serviceManagedEBSVolume != '{}') {
+      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEBSVolume);
       volumeConfigurations = [{
-        name: serviceManagedEbsVolumeName,
-        managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here
+        name: serviceManagedEBSVolumeName,
+        managedEBSVolume: serviceManagedEBSVolume
       }];
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,7 +55,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  let volumeConfigurations;
+  let volumeConfigurations = null;
   let taskManagedEBSVolumeObject;
 
   if (runTaskManagedEBSVolumeName != '') {
@@ -203,7 +203,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
   const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
-  let volumeConfigurations;
+  let volumeConfigurations = null;
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEBSVolumeName != '') {
@@ -326,9 +326,9 @@ function removeIgnoredAttributes(taskDef) {
   for (var attribute of IGNORED_TASK_DEFINITION_ATTRIBUTES) {
     if (taskDef[attribute]) {
       core.warning(`Ignoring property '${attribute}' in the task definition file. ` +
-         'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
-         'but it is not a valid field when registering a new task definition. ' +
-         'This field can be safely removed from your task definition file.');
+        'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
+        'but it is not a valid field when registering a new task definition. ' +
+        'This field can be safely removed from your task definition file.');
       delete taskDef[attribute];
     }
   }
@@ -337,29 +337,29 @@ function removeIgnoredAttributes(taskDef) {
 }
 
 function maintainValidObjects(taskDef) {
-  if (validateProxyConfigurations(taskDef)) {
-    taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
-      if (!('value' in property)) {
-        arr[index].value = '';
-      }
-      if (!('name' in property)) {
-        arr[index].name = '';
-      }
-    });
-  }
-
-  if(taskDef && taskDef.containerDefinitions){
-    taskDef.containerDefinitions.forEach((container) => {
-      if(container.environment){
-        container.environment.forEach((property, index, arr) => {
-          if (!('value' in property)) {
-            arr[index].value = '';
-          }
+    if (validateProxyConfigurations(taskDef)) {
+        taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
+            if (!('value' in property)) {
+                arr[index].value = '';
+            }
+            if (!('name' in property)) {
+                arr[index].name = '';
+            }
         });
-      }
-    });
-  }
-  return taskDef;
+    }
+
+    if(taskDef && taskDef.containerDefinitions){
+      taskDef.containerDefinitions.forEach((container) => {
+        if(container.environment){
+          container.environment.forEach((property, index, arr) => {
+            if (!('value' in property)) {
+              arr[index].value = '';
+            }
+          });
+        }
+      });
+    }
+    return taskDef;
 }
 
 function validateProxyConfigurations(taskDef){
@@ -391,8 +391,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 
   // Insert the task def ARN into the appspec file
   const appSpecPath = path.isAbsolute(codeDeployAppSpecFile) ?
-      codeDeployAppSpecFile :
-      path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
+    codeDeployAppSpecFile :
+    path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
   const fileContents = fs.readFileSync(appSpecPath, 'utf8');
   const appSpecContents = yaml.parse(fileContents);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,20 +55,19 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  let volumeConfigurations = []
-  let volumeConfigurationJSON = {}
+  let volumeConfigurations;
+  let taskManagedEBSVolumeObject;
 
   if (runTaskManagedEBSVolumeName != '') {
     if (runTaskManagedEBSVolume != '{}') {
       taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEbsVolume);
-      volumeConfigurationJSON["name"] = runTaskManagedEbsVolumeName;
-      volumeConfigurationJSON["managedEBSVolume"] = taskManagedEbsVolumeObject;
-      volumeConfigurations.push(volumeConfigurationJSON);
+      volumeConfigurations = [{
+            name: runTaskManagedEBSVolumeName,
+            managedEBSVolume: taskManagedEBSVolumeObject
+      }];
     } else {
       core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. Ignoring run-task-managed-ebs-volume property`);
     }
-  } else {
-    core.info(`No VolumeConfiguration Property provided for run-task-managed-ebs-volume`);
   }
 
   const runTaskResponse = await ecs.runTask({
@@ -199,40 +198,25 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 
 // Deploy to a service that uses the 'ECS' deployment controller
 async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags) {
-  core.debug('Updating the provided ECS service');
+  core.debug('Updating the service');
 
   const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
-  core.debug(`serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}`);
-  core.debug('serviceManagedEbsVolume Name.');
   const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
-  core.debug(`serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}`);
-  core.debug('serviceManagedEbsVolume Value.');
-
-  core.debug('Updating the service contd..');
 
   let volumeConfigurations;
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEbsVolumeName != '') {
-    core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
-    core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
       serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
-      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(serviceManagedEbsVolumeObject)}`);
-
       volumeConfigurations = [{
         name: serviceManagedEbsVolumeName,
         managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here
       }];
-      core.debug('Assigning VolumeConfiguration Object');
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
     }
-  }  else {
-    core.debug('No VolumeConfiguration Property provided for service-managed-ebs-volume');
   }
-  core.debug(`VolumeConfiguration Value: ${volumeConfigurations}`);
-  core.debug('VolumeConfiguration Value Set.');
 
   let params = {
     cluster: clusterName,
@@ -243,10 +227,6 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     propagateTags: propagateTags,
     volumeConfigurations: volumeConfigurations
   };
-
-  core.debug(`Volume Configurations: ${JSON.stringify(volumeConfigurations, null, 2)}`);
-  core.debug(`Managed EBS Volume Object: ${JSON.stringify(serviceManagedEbsVolumeObject, null, 2)}`);
-  core.debug(`Final params: ${JSON.stringify(params, null, 2)}`);
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
@@ -346,9 +326,9 @@ function removeIgnoredAttributes(taskDef) {
   for (var attribute of IGNORED_TASK_DEFINITION_ATTRIBUTES) {
     if (taskDef[attribute]) {
       core.warning(`Ignoring property '${attribute}' in the task definition file. ` +
-          'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
-          'but it is not a valid field when registering a new task definition. ' +
-          'This field can be safely removed from your task definition file.');
+         'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
+         'but it is not a valid field when registering a new task definition. ' +
+         'This field can be safely removed from your task definition file.');
       delete taskDef[attribute];
     }
   }
@@ -511,8 +491,8 @@ async function run() {
     // Register the task definition
     core.debug('Registering the task definition');
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-        taskDefinitionFile :
-        path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+      taskDefinitionFile :
+      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
     const fileContents = fs.readFileSync(taskDefPath, 'utf8');
     const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
     let registerResponse;
@@ -581,7 +561,7 @@ module.exports = run;
 
 /* istanbul ignore next */
 if (require.main === require.cache[eval('__filename')]) {
-  run();
+    run();
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -66,7 +66,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
             managedEBSVolume: taskManagedEBSVolumeObject
       }];
     } else {
-      core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. Ignoring run-task-managed-ebs-volume property`);
+      core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. VolumeConfigurations property will not be included in the RunTask API call`);
     }
   }
 
@@ -214,7 +214,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
         managedEBSVolume: serviceManagedEbsVolumeObject
       }];
     } else {
-      core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
+      core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. VolumeConfigurations property will not be included in the UpdateService API call');
     }
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -211,7 +211,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
       serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEBSVolume);
       volumeConfigurations = [{
         name: serviceManagedEBSVolumeName,
-        managedEBSVolume: serviceManagedEBSVolume
+        managedEBSVolume: serviceManagedEbsVolumeObject
       }];
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');

--- a/dist/index.js
+++ b/dist/index.js
@@ -210,8 +210,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
 
   core.debug('Updating the service contd..');
 
-  let volumeConfigurations = []
-  let volumeConfigurationJSON = {}
+  let volumeConfigurations;
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEbsVolumeName != '') {
@@ -219,9 +218,10 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
       serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
-      volumeConfigurationJSON["name"] = serviceManagedEbsVolumeName;
-      volumeConfigurationJSON["managedEBSVolume"] = serviceManagedEbsVolumeObject;
-      volumeConfigurations.push(volumeConfigurationJSON);
+      volumeConfigurations = [{
+        name: serviceManagedEbsVolumeName,
+        managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here
+      }];
       core.debug('Assigning VolumeConfiguration Object');
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
@@ -229,9 +229,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   }  else {
     core.debug('No VolumeConfiguration Property provided for service-managed-ebs-volume');
   }
-  core.debug('VolumeConfiguration Value: ${volumeConfiguration}');
+  core.debug(`VolumeConfiguration Value: ${volumeConfigurations}`);
   core.debug('VolumeConfiguration Value Set.');
-
 
   let params = {
     cluster: clusterName,
@@ -242,6 +241,10 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     propagateTags: propagateTags,
     volumeConfigurations: volumeConfigurations
   };
+
+  core.debug(`Volume Configurations: ${JSON.stringify(volumeConfigurations, null, 2)}`);
+  core.debug(`Managed EBS Volume Object: ${JSON.stringify(serviceManagedEbsVolumeObject, null, 2)}`);
+  core.debug(`Final params: ${JSON.stringify(params, null, 2)}`);
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -217,7 +217,9 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      serviceManagedEbsVolumeObject = await convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(ebsVolumeObject)}`);
+
       volumeConfigurations = [{
         name: serviceManagedEbsVolumeName,
         managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');
   const capacityProviderStrategy = JSON.parse(core.getInput('run-task-capacity-provider-strategy', { required: false }) || '[]');
-  const runTaskManagedEBSVolumeName = core.getInput('run-task-managed-ebs-volume', { required: false }) || '';
-  const runTaskManagedEBSVolume = core.getInput('run-task-managed-ebs-volume-name', { required: false }) || '{}';
+  const runTaskManagedEBSVolumeName = core.getInput('run-task-managed-ebs-volume-name', { required: false }) || '';
+  const runTaskManagedEBSVolume = core.getInput('run-task-managed-ebs-volume', { required: false }) || '{}';
 
   let awsvpcConfiguration = {}
 
@@ -54,7 +54,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
 
   if (runTaskManagedEBSVolumeName != '') {
     if (runTaskManagedEBSVolume != '{}') {
-      taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEbsVolume);
+      taskManagedEBSVolumeObject = convertToManagedEbsVolumeObject(runTaskManagedEBSVolume);
       volumeConfigurations = [{
             name: runTaskManagedEBSVolumeName,
             managedEBSVolume: taskManagedEBSVolumeObject
@@ -194,18 +194,18 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags) {
   core.debug('Updating the service');
 
-  const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
-  const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
+  const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
+  const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
   let volumeConfigurations;
   let serviceManagedEbsVolumeObject;
 
-  if (serviceManagedEbsVolumeName != '') {
-    if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+  if (serviceManagedEBSVolumeName != '') {
+    if (serviceManagedEBSVolume != '{}') {
+      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEBSVolume);
       volumeConfigurations = [{
-        name: serviceManagedEbsVolumeName,
-        managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here
+        name: serviceManagedEBSVolumeName,
+        managedEBSVolume: serviceManagedEBSVolume
       }];
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');

--- a/index.js
+++ b/index.js
@@ -218,13 +218,16 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     taskDefinition: taskDefArn,
     forceNewDeployment: forceNewDeployment,
     enableECSManagedTags: enableECSManagedTags,
-    propagateTags: propagateTags,
-    volumeConfigurations: volumeConfigurations
+    propagateTags: propagateTags
   };
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
+  }
+  // Add VolumeConfigurations property only it is not null
+  if(volumeConfigurations !== null){
+    params.volumeConfigurations = volumeConfigurations;
   }
   await ecs.updateService(params);
 

--- a/index.js
+++ b/index.js
@@ -211,7 +211,9 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      serviceManagedEbsVolumeObject = await convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(ebsVolumeObject)}`);
+
       volumeConfigurations = [{
         name: serviceManagedEbsVolumeName,
         managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   }
 }
 
-async function convertToManagedEbsVolumeObject(managedEbsVolume) {
+function convertToManagedEbsVolumeObject(managedEbsVolume) {
   managedEbsVolumeObject = {}
   const ebsVolumeObject = JSON.parse(managedEbsVolume);
   if ('roleArn' in ebsVolumeObject){ // required property
@@ -211,8 +211,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
-      serviceManagedEbsVolumeObject = await convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
-      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(ebsVolumeObject)}`);
+      serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
+      core.debug(`EBS Volume Object after conversion: ${JSON.stringify(serviceManagedEbsVolumeObject)}`);
 
       volumeConfigurations = [{
         name: serviceManagedEbsVolumeName,

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
             managedEBSVolume: taskManagedEBSVolumeObject
       }];
     } else {
-      core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. Ignoring run-task-managed-ebs-volume property`);
+      core.warning(`run-task-managed-ebs-volume-name provided without run-task-managed-ebs-volume value. VolumeConfigurations property will not be included in the RunTask API call`);
     }
   }
 
@@ -208,7 +208,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
         managedEBSVolume: serviceManagedEbsVolumeObject
       }];
     } else {
-      core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
+      core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. VolumeConfigurations property will not be included in the UpdateService API call');
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  let volumeConfigurations;
+  let volumeConfigurations = null;
   let taskManagedEBSVolumeObject;
 
   if (runTaskManagedEBSVolumeName != '') {
@@ -197,7 +197,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
   const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
-  let volumeConfigurations;
+  let volumeConfigurations = null;
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEBSVolumeName != '') {
@@ -320,9 +320,9 @@ function removeIgnoredAttributes(taskDef) {
   for (var attribute of IGNORED_TASK_DEFINITION_ATTRIBUTES) {
     if (taskDef[attribute]) {
       core.warning(`Ignoring property '${attribute}' in the task definition file. ` +
-         'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
-         'but it is not a valid field when registering a new task definition. ' +
-         'This field can be safely removed from your task definition file.');
+        'This property is returned by the Amazon ECS DescribeTaskDefinition API and may be shown in the ECS console, ' +
+        'but it is not a valid field when registering a new task definition. ' +
+        'This field can be safely removed from your task definition file.');
       delete taskDef[attribute];
     }
   }
@@ -331,29 +331,29 @@ function removeIgnoredAttributes(taskDef) {
 }
 
 function maintainValidObjects(taskDef) {
-  if (validateProxyConfigurations(taskDef)) {
-    taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
-      if (!('value' in property)) {
-        arr[index].value = '';
-      }
-      if (!('name' in property)) {
-        arr[index].name = '';
-      }
-    });
-  }
-
-  if(taskDef && taskDef.containerDefinitions){
-    taskDef.containerDefinitions.forEach((container) => {
-      if(container.environment){
-        container.environment.forEach((property, index, arr) => {
-          if (!('value' in property)) {
-            arr[index].value = '';
-          }
+    if (validateProxyConfigurations(taskDef)) {
+        taskDef.proxyConfiguration.properties.forEach((property, index, arr) => {
+            if (!('value' in property)) {
+                arr[index].value = '';
+            }
+            if (!('name' in property)) {
+                arr[index].name = '';
+            }
         });
-      }
-    });
-  }
-  return taskDef;
+    }
+
+    if(taskDef && taskDef.containerDefinitions){
+      taskDef.containerDefinitions.forEach((container) => {
+        if(container.environment){
+          container.environment.forEach((property, index, arr) => {
+            if (!('value' in property)) {
+              arr[index].value = '';
+            }
+          });
+        }
+      });
+    }
+    return taskDef;
 }
 
 function validateProxyConfigurations(taskDef){
@@ -385,8 +385,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 
   // Insert the task def ARN into the appspec file
   const appSpecPath = path.isAbsolute(codeDeployAppSpecFile) ?
-      codeDeployAppSpecFile :
-      path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
+    codeDeployAppSpecFile :
+    path.join(process.env.GITHUB_WORKSPACE, codeDeployAppSpecFile);
   const fileContents = fs.readFileSync(appSpecPath, 'utf8');
   const appSpecContents = yaml.parse(fileContents);
 

--- a/index.js
+++ b/index.js
@@ -108,39 +108,40 @@ async function convertToManagedEbsVolumeObject(managedEbsVolume) {
   managedEbsVolumeObject = {}
   const ebsVolumeObject = JSON.parse(managedEbsVolume);
   if ('roleArn' in ebsVolumeObject){ // required property
-    managedEbsVolumeObject['roleArn'] = ebsVolumeObject['roleArn'];
+    managedEbsVolumeObject.roleArn = ebsVolumeObject.roleArn;
     core.debug(`Found RoleArn ${ebsVolumeObject['roleArn']}`);
   } else {
     throw new Error('managed-ebs-volume must provide "role-arn" to associate with the EBS volume')
   }
 
   if ('encrypted' in ebsVolumeObject) {
-    managedEbsVolumeObject['encrypted'] = ebsVolumeObject.encrypted;
+    managedEbsVolumeObject.encrypted = ebsVolumeObject.encrypted;
   }
   if ('filesystemType' in ebsVolumeObject) {
-    managedEbsVolumeObject['filesystemType'] = ebsVolumeObject.filesystemType;
+    managedEbsVolumeObject.filesystemType = ebsVolumeObject.filesystemType;
   }
   if ('iops' in ebsVolumeObject) {
-    managedEbsVolumeObject['iops'] = ebsVolumeObject.iops;
+    managedEbsVolumeObject.iops = ebsVolumeObject.iops;
   }
   if ('kmsKeyId' in ebsVolumeObject) {
-    managedEbsVolumeObject['kmsKeyId'] = ebsVolumeObject.kmsKeyId;
+    managedEbsVolumeObject.kmsKeyId = ebsVolumeObject.kmsKeyId;
   }
   if ('sizeInGiB' in ebsVolumeObject) {
-    managedEbsVolumeObject['sizeInGiB'] = ebsVolumeObject.sizeInGiB;
+    managedEbsVolumeObject.sizeInGiB = ebsVolumeObject.sizeInGiB;
   }
   if ('snapshotId' in ebsVolumeObject) {
-    managedEbsVolumeObject['snapshotId'] = ebsVolumeObject.snapshotId;
+    managedEbsVolumeObject.snapshotId = ebsVolumeObject.snapshotId;
   }
   if ('tagSpecifications' in ebsVolumeObject) {
-    managedEbsVolumeObject['tagSpecifications'] = ebsVolumeObject.tagSpecifications;
+    managedEbsVolumeObject.tagSpecifications = ebsVolumeObject.tagSpecifications;
   }
   if (('throughput' in ebsVolumeObject) && (('volumeType' in ebsVolumeObject) && (ebsVolumeObject.volumeType == 'gp3'))){
-    managedEbsVolumeObject["throughput"] = ebsVolumeObject.throughput;
+    managedEbsVolumeObject.throughput = ebsVolumeObject.throughput;
   }
   if ('volumeType' in ebsVolumeObject) {
-    managedEbsVolumeObject['volumeType'] = ebsVolumeObject.volumeType;
+    managedEbsVolumeObject.volumeType = ebsVolumeObject.volumeType;
   }
+  core.debug(`Created managedEbsVolumeObject: ${JSON.stringify(managedEbsVolumeObject)}`);
   return managedEbsVolumeObject;
 }
 
@@ -195,16 +196,17 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   core.debug('Updating the provided ECS service');
 
   const serviceManagedEbsVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
-  core.debug('serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}');
+  core.debug(`serviceManagedEbsVolume Name: ${serviceManagedEbsVolumeName}`);
   core.debug('serviceManagedEbsVolume Name.');
   const serviceManagedEbsVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
-  core.debug('serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}');
+  core.debug(`serviceManagedEbsVolume Value: ${serviceManagedEbsVolume}`);
   core.debug('serviceManagedEbsVolume Value.');
 
   core.debug('Updating the service contd..');
 
   let volumeConfigurations = []
   let volumeConfigurationJSON = {}
+  let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEbsVolumeName != '') {
     core.debug(`Assigning VolumeConfiguration Name: ${serviceManagedEbsVolumeName}`);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   if(assignPublicIP != "" && (subnetIds != "" || securityGroupIds != "")){
     awsvpcConfiguration["assignPublicIp"] = assignPublicIP
   }
-  let volumeConfigurations = null;
+  let volumeConfigurations = [];
   let taskManagedEBSVolumeObject;
 
   if (runTaskManagedEBSVolumeName != '') {
@@ -197,7 +197,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
   const serviceManagedEBSVolume = core.getInput('service-managed-ebs-volume', { required: false }) || '{}';
 
-  let volumeConfigurations = null;
+  let volumeConfigurations = [];
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEBSVolumeName != '') {
@@ -218,16 +218,13 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     taskDefinition: taskDefArn,
     forceNewDeployment: forceNewDeployment,
     enableECSManagedTags: enableECSManagedTags,
-    propagateTags: propagateTags
+    propagateTags: propagateTags,
+    volumeConfigurations: volumeConfigurations
   };
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
-  }
-  // Add VolumeConfigurations property only it is not null
-  if(volumeConfigurations !== null){
-    params.volumeConfigurations = volumeConfigurations;
   }
   await ecs.updateService(params);
 

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
       serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEBSVolume);
       volumeConfigurations = [{
         name: serviceManagedEBSVolumeName,
-        managedEBSVolume: serviceManagedEBSVolume
+        managedEBSVolume: serviceManagedEbsVolumeObject
       }];
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');

--- a/index.js
+++ b/index.js
@@ -204,8 +204,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
 
   core.debug('Updating the service contd..');
 
-  let volumeConfigurations = []
-  let volumeConfigurationJSON = {}
+  let volumeConfigurations;
   let serviceManagedEbsVolumeObject;
 
   if (serviceManagedEbsVolumeName != '') {
@@ -213,9 +212,10 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     core.debug('Assigning VolumeConfiguration.');
     if (serviceManagedEbsVolume != '{}') {
       serviceManagedEbsVolumeObject = convertToManagedEbsVolumeObject(serviceManagedEbsVolume);
-      volumeConfigurationJSON["name"] = serviceManagedEbsVolumeName;
-      volumeConfigurationJSON["managedEBSVolume"] = serviceManagedEbsVolumeObject;
-      volumeConfigurations.push(volumeConfigurationJSON);
+      volumeConfigurations = [{
+        name: serviceManagedEbsVolumeName,
+        managedEBSVolume: serviceManagedEbsVolumeObject  // Note the exact casing here
+      }];
       core.debug('Assigning VolumeConfiguration Object');
     } else {
       core.warning('service-managed-ebs-volume-name provided without service-managed-ebs-volume value. Ignoring service-managed-ebs-volume property');
@@ -223,9 +223,8 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   }  else {
     core.debug('No VolumeConfiguration Property provided for service-managed-ebs-volume');
   }
-  core.debug('VolumeConfiguration Value: ${volumeConfiguration}');
+  core.debug(`VolumeConfiguration Value: ${volumeConfigurations}`);
   core.debug('VolumeConfiguration Value Set.');
-
 
   let params = {
     cluster: clusterName,
@@ -236,6 +235,10 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
     propagateTags: propagateTags,
     volumeConfigurations: volumeConfigurations
   };
+
+  core.debug(`Volume Configurations: ${JSON.stringify(volumeConfigurations, null, 2)}`);
+  core.debug(`Managed EBS Volume Object: ${JSON.stringify(serviceManagedEbsVolumeObject, null, 2)}`);
+  core.debug(`Final params: ${JSON.stringify(params, null, 2)}`);
 
   // Add the desiredCount property only if it is defined and a number.
   if (!isNaN(desiredCount) && desiredCount !== undefined) {

--- a/index.test.js
+++ b/index.test.js
@@ -187,7 +187,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenCalledTimes(0);
         expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the Amazon ECS console: https://fake-region.console.aws.amazon.com/ecs/v2/clusters/cluster-789/services/service-456/events?region=fake-region");
@@ -220,7 +221,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenCalledTimes(0);
         expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the Amazon ECS console: https://fake-region.console.aws.amazon.com/ecs/v2/clusters/cluster-789/services/service-456/events?region=fake-region");
@@ -955,7 +957,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
             1,
@@ -996,7 +999,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
             1,
@@ -1037,7 +1041,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
             1,
@@ -1080,7 +1085,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: true,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
     });
 
@@ -1106,7 +1112,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'NONE'
+            propagateTags: 'NONE',
+            volumeConfigurations: []
         });
     });
 
@@ -1153,7 +1160,8 @@ describe('Deploy to ECS', () => {
             overrides: {"containerOverrides": []},
             networkConfiguration: null,
             enableECSManagedTags: null,
-            tags: []
+            tags: [],
+            volumeConfigurations: []
         });
 
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'run-task-arn', ["arn:aws:ecs:fake-region:account_id:task/arn"]);
@@ -1195,7 +1203,8 @@ describe('Deploy to ECS', () => {
             overrides: { containerOverrides: [{ name: 'someapp', command: 'somecmd' }] },
             networkConfiguration: { awsvpcConfiguration: { subnets: ['a', 'b'], securityGroups: ['c', 'd'], assignPublicIp: "DISABLED" } },
             enableECSManagedTags: false,
-            tags: [{"key": "project", "value": "myproject"}]
+            tags: [{"key": "project", "value": "myproject"}],
+            volumeConfigurations: []
         });
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'run-task-arn', ["arn:aws:ecs:fake-region:account_id:task/arn"]);
     });
@@ -1238,6 +1247,7 @@ describe('Deploy to ECS', () => {
             networkConfiguration: { awsvpcConfiguration: { subnets: ['a', 'b'], securityGroups: ['c', 'd'], assignPublicIp: "DISABLED" } },
             enableECSManagedTags: false,
             tags: [{"key": "project", "value": "myproject"}],
+            volumeConfigurations: []
         });
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'run-task-arn', ["arn:aws:ecs:fake-region:account_id:task/arn"]);
     });
@@ -1278,6 +1288,7 @@ describe('Deploy to ECS', () => {
             forceNewDeployment: false,
             enableECSManagedTags: null,
             propagateTags: 'NONE',
+            volumeConfigurations: []
         });
         expect(mockRunTask).toHaveBeenCalledWith({
             startedBy: 'someJoe',
@@ -1288,7 +1299,8 @@ describe('Deploy to ECS', () => {
             overrides: { containerOverrides: [{ name: 'someapp', command: 'somecmd' }] },
             networkConfiguration: { awsvpcConfiguration: { subnets: ['a', 'b'], securityGroups: ['c', 'd'], assignPublicIp: "DISABLED" } },
             enableECSManagedTags: null,
-            tags: []
+            tags: [],
+            volumeConfigurations: []
         });
         expect(core.setOutput).toHaveBeenNthCalledWith(2, 'run-task-arn', ["arn:aws:ecs:fake-region:account_id:task/arn"]);
     });
@@ -1349,7 +1361,8 @@ describe('Deploy to ECS', () => {
             overrides: { containerOverrides: [] },
             networkConfiguration: null,
             enableECSManagedTags: null,
-            tags: []
+            tags: [],
+            volumeConfigurations: []
         });
     });
     
@@ -1377,7 +1390,8 @@ describe('Deploy to ECS', () => {
             overrides: { containerOverrides: [] },
             networkConfiguration: null,
             enableECSManagedTags: true,
-            tags: []
+            tags: [],
+            volumeConfigurations: []
         });
     });
     
@@ -1405,7 +1419,8 @@ describe('Deploy to ECS', () => {
             overrides: { containerOverrides: [] },
             networkConfiguration: null,
             enableECSManagedTags: false,
-            tags: []
+            tags: [],
+            volumeConfigurations: []
         });
     });
 
@@ -1603,7 +1618,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: null,
-            propagateTags: 'SERVICE'
+            propagateTags: 'SERVICE',
+            volumeConfigurations: []
         });
     });
     
@@ -1635,7 +1651,8 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: true,
-            propagateTags: 'SERVICE'
+            propagateTags: 'SERVICE',
+            volumeConfigurations: []
         });
     });
     
@@ -1667,7 +1684,235 @@ describe('Deploy to ECS', () => {
             taskDefinition: 'task:def:arn',
             forceNewDeployment: false,
             enableECSManagedTags: false,
-            propagateTags: 'SERVICE'
+            propagateTags: 'SERVICE',
+            volumeConfigurations: []
+        });
+    });
+
+    test('update service with new EBS volume configuration', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                console.log(`Getting input for: ${name}`);
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': 'service-456',
+                    'cluster': 'cluster-789',
+                    'service-managed-ebs-volume-name': 'ebs1',
+                    'service-managed-ebs-volume': JSON.stringify({
+                        filesystemType: "xfs",
+                        roleArn: "arn:aws:iam::123:role/ebs-role",
+                        encrypted: false,
+                        sizeInGiB: 30
+                    }),
+                    'run-task': 'false'
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            service: 'service-456',
+            taskDefinition: 'task:def:arn',
+            forceNewDeployment: false,
+            enableECSManagedTags: null,
+            propagateTags: 'NONE',
+            volumeConfigurations: [{
+                name: 'ebs1',
+                managedEBSVolume: {
+                    filesystemType: "xfs",
+                    roleArn: "arn:aws:iam::123:role/ebs-role",
+                    encrypted: false,
+                    sizeInGiB: 30
+                }
+            }]
+        });
+    });
+
+    test('update existing EBS volume configuration in an ECS Service', async () => {
+        // First create a service with initial EBS configuration
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': 'service-456',
+                    'cluster': 'cluster-789',
+                    'service-managed-ebs-volume-name': 'ebs1',
+                    'service-managed-ebs-volume': JSON.stringify({
+                        filesystemType: "xfs",
+                        roleArn: "arn:aws:iam::123:role/ebs-role",
+                        encrypted: false,
+                        sizeInGiB: 30
+                    }),
+                    'run-task': 'false'
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        // Then update the service with new EBS configuration
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': 'service-456',
+                    'cluster': 'cluster-789',
+                    'service-managed-ebs-volume-name': 'ebs1',
+                    'service-managed-ebs-volume': JSON.stringify({
+                        filesystemType: "xfs",
+                        roleArn: "arn:aws:iam::123:role/ebs-role",
+                        encrypted: true,  // Changed
+                        sizeInGiB: 50     // Changed
+                    }),
+                    'run-task': 'false'
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        // Verify the second call had the updated configuration
+        expect(mockEcsUpdateService).toHaveBeenNthCalledWith(2, {
+            cluster: 'cluster-789',
+            service: 'service-456',
+            taskDefinition: 'task:def:arn',
+            forceNewDeployment: false,
+            enableECSManagedTags: null,
+            propagateTags: 'NONE',
+            volumeConfigurations: [{
+                name: 'ebs1',
+                managedEBSVolume: {
+                    filesystemType: "xfs",
+                    roleArn: "arn:aws:iam::123:role/ebs-role",
+                    encrypted: true,
+                    sizeInGiB: 50
+                }
+            }]
+        });
+    });
+
+    test('remove service EBS volume configuration', async () => {
+
+        // First call - create service with EBS configuration
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': 'service-456',
+                    'cluster': 'cluster-789',
+                    'service-managed-ebs-volume-name': 'ebs1',
+                    'service-managed-ebs-volume': JSON.stringify({
+                        filesystemType: "xfs",
+                        roleArn: "arn:aws:iam::123:role/ebs-role",
+                        encrypted: false,
+                        sizeInGiB: 30
+                    }),
+                    'run-task': 'false'
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        // Second call - remove EBS configuration
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': 'service-456',
+                    'cluster': 'cluster-789',
+                    'run-task': 'false'
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        // Verify both calls were made correctly
+        expect(mockEcsUpdateService).toHaveBeenCalledTimes(2);
+
+        // Verify first call had the EBS configuration
+        expect(mockEcsUpdateService.mock.calls[0][0]).toEqual({
+            cluster: 'cluster-789',
+            service: 'service-456',
+            taskDefinition: 'task:def:arn',
+            forceNewDeployment: false,
+            enableECSManagedTags: null,
+            propagateTags: 'NONE',
+            volumeConfigurations: [{
+                name: 'ebs1',
+                managedEBSVolume: {
+                    filesystemType: "xfs",
+                    roleArn: "arn:aws:iam::123:role/ebs-role",
+                    encrypted: false,
+                    sizeInGiB: 30
+                }
+            }]
+        });
+
+        // Verify second call had empty volume configurations
+        expect(mockEcsUpdateService.mock.calls[1][0]).toEqual({
+            cluster: 'cluster-789',
+            service: 'service-456',
+            taskDefinition: 'task:def:arn',
+            forceNewDeployment: false,
+            enableECSManagedTags: null,
+            propagateTags: 'NONE',
+            volumeConfigurations: []
+        });
+    });
+
+    test('run task with EBS volume configuration', async () => {
+        core.getInput = jest
+            .fn()
+            .mockImplementation((name) => {
+                const inputs = {
+                    'task-definition': 'task-definition.json',
+                    'service': '',
+                    'cluster': 'cluster-789',
+                    'run-task': 'true',
+                    'run-task-launch-type': 'EC2',
+                    'run-task-managed-ebs-volume-name': 'ebs1',
+                    'run-task-managed-ebs-volume': JSON.stringify({
+                        filesystemType: "xfs",
+                        roleArn: "arn:aws:iam::123:role/ebs-role",
+                        encrypted: false,
+                        sizeInGiB: 30
+                    })
+                };
+                return inputs[name] || '';
+            });
+
+        await run();
+
+        expect(mockRunTask).toHaveBeenCalledWith({
+            cluster: 'cluster-789',
+            taskDefinition: 'task:def:arn',
+            startedBy: 'GitHub-Actions',
+            capacityProviderStrategy: null,
+            launchType: 'EC2',
+            enableECSManagedTags: null,
+            tags: [],
+            overrides: {
+                containerOverrides: []
+            },
+            networkConfiguration: null,
+            volumeConfigurations: [{
+                name: 'ebs1',
+                managedEBSVolume: {
+                    filesystemType: "xfs",
+                    roleArn: "arn:aws:iam::123:role/ebs-role",
+                    encrypted: false,
+                    sizeInGiB: 30
+                }
+            }]
         });
     });
 });


### PR DESCRIPTION
*Issue #, if available: n/A

### Description of changes:

This PR enhances the `amazon-ecs-deploy-task-definition` GitHub Action to support Amazon ECS Managed EBS Volumes for both RunTask and UpdateService operations. The changes include:
1. Introduced new input parameters:
   - `run-task-managed-ebs-volume-name`
   - `run-task-managed-ebs-volume`
   - `service-managed-ebs-volume-name`
   - `service-managed-ebs-volume`
2. Added support for VolumeConfiguration property during runTask api call if the `run-task-managed-ebs-volume-name`
and `run-task-managed-ebs-volume` parameters have been set.
3. Added support for VolumeConfiguration property during updateService api call if the `service-managed-ebs-volume-name` and `service-managed-ebs-volume` parameters have been set. 

## Usage:

To use `VolumeConfigurations` property in `runTask` and `UpdateService` update your task definition to support an ECS volume that is configured at launch, and update your workflow file to look like below:

__For RunTask:__

```
workflow.yaml
....
- uses: aws-actions/amazon-ecs-deploy-task-definition@v1
  with:
    task-definition: .aws/task-definition-run-task.json
          cluster: ${{ env.ECS_CLUSTER }}
          run-task: true
          run-task-launch-type: EC2
          run-task-managed-ebs-volume-name: "ebs1"
          run-task-managed-ebs-volume: '{"sizeInGiB": 30, "volumeType": "gp3", "encrypted": true, "roleArn":"<>"}'
```

__For UpdateService:__
```
workflow.yaml
...
- name: Deploy ECS task definition to ECS Service
        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
        with:
          task-definition: .aws/task-definition.json
          service: ${{ env.ECS_SERVICE }}
          cluster: ${{ env.ECS_CLUSTER }}
          run-task-managed-ebs-volume-name: "ebs1"
          run-task-managed-ebs-volume: '{"sizeInGiB": 30, "volumeType": "gp3", "encrypted": true, "roleArn":"<>"}'
```

__Task Definition Example:__
```json
{
    "volumes": [
        {
            "name": "ebs1",
            "configuredAtLaunch": true
        }
    ]
}
```

__Testing:__
Manually Tested below use cases:
 * Updating a Service to use a EBSVolumeConfiguration
 * Updating a Service using EBSVolumeConfiguration to modify the existing configuration
 * Updating a TaskDefinition and Service to no longer a EBSVolumeConfiguration
 * RunTask api call to run a task with EBSVolume configured

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
