### PR TITLE
fix: propagate `run-task-arn` to outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,9 @@ outputs:
     description: 'The ARN of the registered ECS task definition.'
   codedeploy-deployment-id:
     description: 'The deployment ID of the CodeDeploy deployment (if the ECS service uses the CODE_DEPLOY deployment controller).'
+  run-task-arn:
+    description: 'The ARN(s) of the task(s) that were started by the run-task option. Output is in an array JSON format.'
+
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
*Issue #, if available:*
- none

*Description of changes:*
- In https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/304, the addition of the `run-task-arn` output implemented [in index.js](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/blob/8ef49e87170f62b9e341907dc88cffc1615e3b0d/index.js#L85) was accidentally omitted from action.yml.
- This fix allows users of this action to reference the ARN of the executed task, thereby enhancing usability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
