### PR TITLE
Add support for `maxAttempts` to allow retrying when failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Registers an Amazon ECS task definition and deploys it to an ECS service.
 
 ## Usage
 
+The action supports the following inputs:
+
+* `task-definition` (required) - The path to the ECS task definition file (JSON format) to register.
+* `max-retries` (optional) - The maximum number of retry attempts for AWS API calls. The action uses exponential backoff with jitter for retries. Defaults to 3.
+* `service` (optional) - The name of the ECS service to update with the new task definition. If empty, the action will not attempt to update a service.
+
 ```yaml
     - name: Deploy to Amazon ECS
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,9 @@ inputs:
   propagate-tags:
     description: "Determines to propagate the tags from the 'SERVICE' to the task."
     required: false
+  max-retries:
+    description: 'The maximum number of retry attempts for AWS API calls. Defaults to 3.'
+    required: false
 outputs:
   task-definition-arn:
     description: 'The ARN of the registered ECS task definition.'

--- a/index.js
+++ b/index.js
@@ -454,11 +454,18 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 
 async function run() {
   try {
+    const maxRetries = parseInt(core.getInput('max-retries', { required: false })) || 3;
+
     const ecs = new ECS({
-      customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions'
+      customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions',
+      maxAttempts: maxRetries,
+      retryMode: 'standard'
     });
+
     const codedeploy = new CodeDeploy({
-      customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions'
+      customUserAgent: 'amazon-ecs-deploy-task-definition-for-github-actions',
+      maxAttempts: maxRetries,
+      retryMode: 'standard'
     });
 
     // Get inputs


### PR DESCRIPTION
### Context
I know there's already an effort to get this change merged [here](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/510) but it seems like it fell through the cracks after the upgrade to AWS SDK for Javascript (v3). 

It appears that a lot of users of this action are encountering rate limits when attempting to deploy task definitions in parallel. This should help mitigate the issue.

### Implementation

Allows retries using the updated client specs with `maxAttempts` and `retryMode`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
