### PR TITLE
feat: Set url to deployments instead of events

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   const region = await ecs.config.region();
   const consoleHostname = region.startsWith('cn') ? 'console.amazonaws.cn' : 'console.aws.amazon.com';
 
-  core.info(`Deployment started. Watch this deployment's progress in the Amazon ECS console: https://${region}.${consoleHostname}/ecs/v2/clusters/${clusterName}/services/${service}/events?region=${region}`);
+  core.info(`Deployment started. Watch this deployment's progress in the Amazon ECS console: https://${region}.${consoleHostname}/ecs/v2/clusters/${clusterName}/services/${service}/deployments?region=${region}`);
 
   // Wait for service stability
   if (waitForService && waitForService.toLowerCase() === 'true') {


### PR DESCRIPTION
Closes: #677 

*Description of changes:*
Use deployments console for the job log.
Events are present at the bottom of the deployment page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
