### PR TITLE
Support ARN being passed in as well as a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Registers an Amazon ECS task definition and deploys it to an ECS service.
 <!-- toc -->
 
 - [Usage](#usage)
-  - [Task definition file](#task-definition-file)
-  - [Task definition container image values](#task-definition-container-image-values)
+    + [Task definition file](#task-definition-file)
+    + [Task definition container image values](#task-definition-container-image-values)
 - [Credentials and Region](#credentials-and-region)
 - [Permissions](#permissions)
 - [AWS CodeDeploy Support](#aws-codedeploy-support)
@@ -31,15 +31,14 @@ Registers an Amazon ECS task definition and deploys it to an ECS service.
 ```
 
 See [action.yml](action.yml) for the full documentation for this action's inputs and outputs.
-In most cases when running a one-off task, subnet ID's, subnet groups, and assign public IP will be required.
-Assign public IP will only be applied when a subnet or security group is defined.
+In most cases when running a one-off task, subnet ID's, subnet groups, and assign public IP will be required. 
+Assign public IP will only be applied when a subnet or security group is defined. 
 
 ### Task definition file
 
 It is highly recommended to treat the task definition "as code" by checking it into your git repository as a JSON file.  Changes to any task definition attributes like container images, environment variables, CPU, and memory can be deployed with this GitHub action by editing your task definition file and pushing a new git commit.
 
 An existing task definition can be downloaded to a JSON file with the following command.  Account IDs can be removed from the file by removing the `taskDefinitionArn` attribute, and updating the `executionRoleArn` and `taskRoleArn` attribute values to contain role names instead of role ARNs.
-
 ```sh
 aws ecs describe-task-definition \
    --task-definition my-task-definition-family \
@@ -47,14 +46,12 @@ aws ecs describe-task-definition \
 ```
 
 Alternatively, you can start a new task definition file from scratch with the following command.  In the generated file, fill in your attribute values and remove any attributes not needed for your application.
-
 ```sh
 aws ecs register-task-definition \
    --generate-cli-skeleton > task-definition.json
 ```
 
 If you do not wish to store your task definition as a file in your git repository, your GitHub Actions workflow can download the existing task definition.
-
 ```yaml
     - name: Download task definition
       run: |
@@ -111,9 +108,9 @@ If you're using CloudFormation tools such as AWS CDK, Serverless Framework, or o
 
 ```yaml
     - name: Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:
-        task-definition: arn:aws:ecs:<region>:<aws_account_id>:task-definition/<task_definition_name>:<revision_number>
+        task-definition-arn: arn:aws:ecs:<region>:<aws_account_id>:task-definition/<task_definition_name>:<revision_number>
         service: my-service
         cluster: my-cluster
         wait-for-service-stability: true
@@ -153,16 +150,15 @@ This action relies on the [default behavior of the AWS SDK for Javascript](https
 Use [the `aws-actions/configure-aws-credentials` action](https://github.com/aws-actions/configure-aws-credentials) to configure the GitHub Actions environment with environment variables containing AWS credentials and your desired region.
 
 We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) for the AWS credentials used in GitHub Actions workflows, including:
-- Do not store credentials in your repository's code.  You may use [GitHub Actions secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) to store credentials and redact credentials from GitHub Actions workflow logs.
-- [Create an individual IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users) with an access key for use in GitHub Actions workflows, preferably one per repository. Do not use the AWS account root user access key.
-- [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) to the credentials used in GitHub Actions workflows.  Grant only the permissions required to perform the actions in your GitHub Actions workflows.  See the Permissions section below for the permissions required by this action.
-- [Rotate the credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#rotate-credentials) used in GitHub Actions workflows regularly.
-- [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
+* Do not store credentials in your repository's code.  You may use [GitHub Actions secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) to store credentials and redact credentials from GitHub Actions workflow logs.
+* [Create an individual IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users) with an access key for use in GitHub Actions workflows, preferably one per repository. Do not use the AWS account root user access key.
+* [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege) to the credentials used in GitHub Actions workflows.  Grant only the permissions required to perform the actions in your GitHub Actions workflows.  See the Permissions section below for the permissions required by this action.
+* [Rotate the credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#rotate-credentials) used in GitHub Actions workflows regularly.
+* [Monitor the activity](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#keep-a-log) of the credentials used in GitHub Actions workflows.
 
 ## Permissions
 
 Running a service requires the following minimum set of permissions:
-
 ```json
 {
    "Version":"2012-10-17",
@@ -200,9 +196,8 @@ Running a service requires the following minimum set of permissions:
    ]
 }
 ```
-
+ 
 Running a one-off/stand-alone task requires the following minimum set of permissions:
-
 ```json
 {
    "Version": "2012-10-17",
@@ -231,7 +226,6 @@ Running a one-off/stand-alone task requires the following minimum set of permiss
    ]
 }
 ```
-
 Note: the policy above assumes the account has opted in to the ECS long ARN format.
 
 ## AWS CodeDeploy Support
@@ -316,15 +310,15 @@ In the following example, the service would not be updated until the ad-hoc task
         wait-for-task-stopped: true
 ```
 
-Overrides and VPC networking options are available as well. See [action.yml](action.yml) for more details. The `FARGATE`
+Overrides and VPC networking options are available as well. See [action.yml](action.yml) for more details. The `FARGATE` 
 launch type requires `awsvpc` network mode in your task definition and you must specify a network configuration.
 
 ### Tags
 
 To tag your tasks:
 
-- to turn on Amazon ECS-managed tags (`aws:ecs:clusterName`), use `enable-ecs-managed-tags`
-- for custom tags, use `run-task-tags`
+* to turn on Amazon ECS-managed tags (`aws:ecs:clusterName`), use `enable-ecs-managed-tags`
+* for custom tags, use `run-task-tags`
 
 ```yaml
     - name: Deploy to Amazon ECS
@@ -351,3 +345,4 @@ This code is made available under the MIT license.
 ## Security Disclosures
 
 If you would like to report a potential security issue in this project, please do not create a GitHub issue.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,11 @@ branding:
   color: 'orange'
 inputs:
   task-definition:
-    description: 'The path to the ECS task definition file to register.'
-    required: true
+    description: 'The path to the ECS task definition file to register. Either this or task-definition-arn must be provided.'
+    required: false
+  task-definition-arn:
+    description: 'The ARN of an existing ECS task definition to deploy. Either this or task-definition must be provided.'
+    required: false
   desired-count:
     description: 'The number of instantiations of the task to place and keep running in your service.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -391,7 +391,8 @@ async function run() {
     });
 
     // Get inputs
-    const taskDefinitionContent = core.getInput('task-definition', { required: true });
+    const taskDefinitionArn = core.getInput('task-definition-arn', { required: false });
+    const taskDefinitionFile = core.getInput('task-definition', { required: false });
     const service = core.getInput('service', { required: false });
     const cluster = core.getInput('cluster', { required: false });
     const waitForService = core.getInput('wait-for-service-stability', { required: false });
@@ -413,18 +414,14 @@ async function run() {
 
     let taskDefArn = null;
 
-    // Of taskDefContent starts with arn: then we assume it is a task definition ARN
-    if (taskDefinitionContent.startsWith("arn:")) {
-      taskDefArn = taskDefinitionContent;
-
-    // 
-    // Else we assume it is a task definition file
-    } else {
-      const taskDefinitionFile = taskDefinitionContent;
-
+    // Prioritize task-definition-arn if provided
+    if (taskDefinitionArn) {
+      taskDefArn = taskDefinitionArn;
+    } else if (taskDefinitionFile) {
+      // Fall back to task-definition file if provided
       core.debug('Registering the task definition');
       const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-        taskDefinitionFile :
+      taskDefinitionFile :
         path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
       const fileContents = fs.readFileSync(taskDefPath, 'utf8');
       const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents))));
@@ -437,6 +434,10 @@ async function run() {
         core.debug(JSON.stringify(taskDefContents, undefined, 4));
         throw(error);
       }
+    } else {
+      // Error if neither is provided
+      core.setFailed('Either task-definition or task-definition-arn must be provided');
+      throw new Error('Either task-definition or task-definition-arn must be provided');
     }
 
     if (!taskDefArn) {
@@ -502,7 +503,7 @@ module.exports = run;
 if (require.main === require.cache[eval('__filename')]) {
     run();
 }
-// 
+
 
 /***/ }),
 


### PR DESCRIPTION
Trying to resurrect https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/658, as the functionality is useful. Tried to address the comment. 

Original PR description

> An up to date version of https://github.com/aws-actions/amazon-ecs-deploy-task-definition/pull/524 PR which should support the AWS SDK v3.