### PR TITLE
chore:upgrade to node 24 to remove deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,5 +105,5 @@ outputs:
     description: 'The ARN(s) of the task(s) that were started by the run-task option. Output is in an array JSON format.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
*Issue #, if available:*
#845 

 *Description of changes:*
This updates the node version to node24 in the action to resolve deprecation warnings which addresses #845 


