### PR TITLE
fix: Detect deployment rollback after service stabilization

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -203,7 +203,7 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 }
 
 // Deploy to a service that uses the 'ECS' deployment controller
-async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds) {
+async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds, beforeDeploymentId) {
   core.debug('Updating the service');
 
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
@@ -238,7 +238,11 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
   }
-  await ecs.updateService(params);
+  const updateResponse = await ecs.updateService(params);
+
+  // Extract the PRIMARY deployment ID from the update response
+  const primaryDeployment = (updateResponse.service.deployments || []).find(d => d.status === 'PRIMARY');
+  const afterDeploymentId = primaryDeployment ? primaryDeployment.id : null;
 
   const region = await ecs.config.region();
   const consoleHostname = region.startsWith('cn') ? 'console.amazonaws.cn' : 'console.aws.amazon.com';
@@ -263,6 +267,36 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
       services: [service],
       cluster: clusterName
     });
+
+    // Verify the deployment was successful (not rolled back)
+    if (afterDeploymentId && afterDeploymentId !== beforeDeploymentId) {
+      core.debug('Verifying deployment succeeded after service stability...');
+
+      const verifyResponse = await ecs.describeServices({
+        services: [service],
+        cluster: clusterName
+      });
+
+      const verifiedService = verifyResponse.services[0];
+      const deployment = (verifiedService.deployments || []).find(d => d.id === afterDeploymentId);
+
+      if (!deployment) {
+        throw new Error(
+          `Deployment ${afterDeploymentId} not found after stabilization. ` +
+          `The deployment was likely rolled back by the deployment circuit breaker.`
+        );
+      }
+
+      if (deployment.rolloutState === 'FAILED') {
+        throw new Error(
+          `Deployment ${afterDeploymentId} FAILED: ${deployment.rolloutStateReason || 'unknown reason'}`
+        );
+      }
+
+      core.info(`Deployment ${afterDeploymentId} verified: rolloutState=${deployment.rolloutState || 'N/A'}`);
+    } else {
+      core.debug('No new deployment was created by the update, skipping deployment verification');
+    }
   } else {
     core.debug('Not waiting for the service to become stable');
   }
@@ -591,8 +625,11 @@ async function run() {
 
       if (!serviceResponse.deploymentController || !serviceResponse.deploymentController.type || serviceResponse.deploymentController.type === 'ECS') {
         // Service uses the 'ECS' deployment controller, so we can call UpdateService
+        const beforePrimaryDeployment = (serviceResponse.deployments || []).find(d => d.status === 'PRIMARY');
+        const beforeDeploymentId = beforePrimaryDeployment ? beforePrimaryDeployment.id : null;
+
         core.debug('Updating service...');
-        await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds);
+        await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds, beforeDeploymentId);
 
       } else if (serviceResponse.deploymentController.type === 'CODE_DEPLOY') {
         // Service uses CodeDeploy, so we should start a CodeDeploy deployment

--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ async function tasksExitCode(ecs, clusterName, taskArns) {
 }
 
 // Deploy to a service that uses the 'ECS' deployment controller
-async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds) {
+async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds, beforeDeploymentId) {
   core.debug('Updating the service');
 
   const serviceManagedEBSVolumeName = core.getInput('service-managed-ebs-volume-name', { required: false }) || '';
@@ -232,7 +232,11 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
   if (!isNaN(desiredCount) && desiredCount !== undefined) {
     params.desiredCount = desiredCount;
   }
-  await ecs.updateService(params);
+  const updateResponse = await ecs.updateService(params);
+
+  // Extract the PRIMARY deployment ID from the update response
+  const primaryDeployment = (updateResponse.service.deployments || []).find(d => d.status === 'PRIMARY');
+  const afterDeploymentId = primaryDeployment ? primaryDeployment.id : null;
 
   const region = await ecs.config.region();
   const consoleHostname = region.startsWith('cn') ? 'console.amazonaws.cn' : 'console.aws.amazon.com';
@@ -257,6 +261,36 @@ async function updateEcsService(ecs, clusterName, service, taskDefArn, waitForSe
       services: [service],
       cluster: clusterName
     });
+
+    // Verify the deployment was successful (not rolled back)
+    if (afterDeploymentId && afterDeploymentId !== beforeDeploymentId) {
+      core.debug('Verifying deployment succeeded after service stability...');
+
+      const verifyResponse = await ecs.describeServices({
+        services: [service],
+        cluster: clusterName
+      });
+
+      const verifiedService = verifyResponse.services[0];
+      const deployment = (verifiedService.deployments || []).find(d => d.id === afterDeploymentId);
+
+      if (!deployment) {
+        throw new Error(
+          `Deployment ${afterDeploymentId} not found after stabilization. ` +
+          `The deployment was likely rolled back by the deployment circuit breaker.`
+        );
+      }
+
+      if (deployment.rolloutState === 'FAILED') {
+        throw new Error(
+          `Deployment ${afterDeploymentId} FAILED: ${deployment.rolloutStateReason || 'unknown reason'}`
+        );
+      }
+
+      core.info(`Deployment ${afterDeploymentId} verified: rolloutState=${deployment.rolloutState || 'N/A'}`);
+    } else {
+      core.debug('No new deployment was created by the update, skipping deployment verification');
+    }
   } else {
     core.debug('Not waiting for the service to become stable');
   }
@@ -585,8 +619,11 @@ async function run() {
 
       if (!serviceResponse.deploymentController || !serviceResponse.deploymentController.type || serviceResponse.deploymentController.type === 'ECS') {
         // Service uses the 'ECS' deployment controller, so we can call UpdateService
+        const beforePrimaryDeployment = (serviceResponse.deployments || []).find(d => d.status === 'PRIMARY');
+        const beforeDeploymentId = beforePrimaryDeployment ? beforePrimaryDeployment.id : null;
+
         core.debug('Updating service...');
-        await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds);
+        await updateEcsService(ecs, clusterName, service, taskDefArn, waitForService, waitForMinutes, forceNewDeployment, desiredCount, enableECSManagedTags, propagateTags, waitMaxDelaySeconds, beforeDeploymentId);
 
       } else if (serviceResponse.deploymentController.type === 'CODE_DEPLOY') {
         // Service uses CodeDeploy, so we should start a CodeDeploy deployment

--- a/index.test.js
+++ b/index.test.js
@@ -91,13 +91,26 @@ describe('Deploy to ECS', () => {
             () => Promise.resolve({ taskDefinition: { taskDefinitionArn: 'task:def:arn' } })
         );
 
-        mockEcsUpdateService.mockImplementation(() => Promise.resolve({}));
+        mockEcsUpdateService.mockImplementation(() => Promise.resolve({
+            service: {
+                deployments: [{
+                    id: 'deployment-new-1',
+                    status: 'PRIMARY',
+                    rolloutState: 'IN_PROGRESS'
+                }]
+            }
+        }));
 
         mockEcsDescribeServices.mockImplementation(
             () => Promise.resolve({
                 failures: [],
                 services: [{
-                    status: 'ACTIVE'
+                    status: 'ACTIVE',
+                    deployments: [{
+                        id: 'deployment-old-1',
+                        status: 'PRIMARY',
+                        rolloutState: 'COMPLETED'
+                    }]
                 }]
             })
         );
@@ -1127,24 +1140,26 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
             .mockReturnValueOnce('');                    // desired count
 
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
+
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
 
-        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family' });
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
-        expect(mockEcsDescribeServices).toHaveBeenNthCalledWith(1, {
-            cluster: 'cluster-789',
-            services: ['service-456']
-        });
-        expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
-            cluster: 'cluster-789',
-            service: 'service-456',
-            taskDefinition: 'task:def:arn',
-            forceNewDeployment: false,
-            enableECSManagedTags: null,
-            propagateTags: null,
-            volumeConfigurations: []
-        });
+        expect(mockEcsDescribeServices).toHaveBeenCalledTimes(2);
         expect(waitUntilServicesStable).toHaveBeenNthCalledWith(
             1,
             {
@@ -1169,6 +1184,22 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('TRUE')                 // wait-for-service-stability
             .mockReturnValueOnce('60')                   // wait-for-minutes
             .mockReturnValueOnce('');                    // desired count
+
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1213,6 +1244,22 @@ describe('Deploy to ECS', () => {
             .mockReturnValueOnce('1000')                 // wait-for-minutes
             .mockReturnValueOnce('abc');                 // desired count is NaN
 
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
+
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
 
@@ -1254,6 +1301,22 @@ describe('Deploy to ECS', () => {
             if (input === 'wait-max-delay-seconds') return '15';
             return '';
         });
+
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
@@ -1481,6 +1544,22 @@ describe('Deploy to ECS', () => {
             return '';
         });
 
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
+
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
 
@@ -1593,6 +1672,22 @@ describe('Deploy to ECS', () => {
                 if (input === 'run-task-managed-ebs-volume') return '{}';
                 return '';
             });
+
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-new-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
 
         await run();
         expect(mockRunTask).toHaveBeenCalledWith({
@@ -2152,5 +2247,98 @@ describe('Deploy to ECS', () => {
                 }
             }]
         });
+    });
+
+    test('fails if deployment is rolled back by circuit breaker', async () => {
+        core.getInput = jest.fn(input => {
+            if (input === 'task-definition') return 'task-definition.json';
+            if (input === 'service') return 'service-456';
+            if (input === 'cluster') return 'cluster-789';
+            if (input === 'wait-for-service-stability') return 'true';
+            return '';
+        });
+
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }));
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(1);
+        expect(core.setFailed).toHaveBeenCalledWith(
+            expect.stringContaining('not found after stabilization')
+        );
+    });
+
+    test('fails if deployment rolloutState is FAILED', async () => {
+        core.getInput = jest.fn(input => {
+            if (input === 'task-definition') return 'task-definition.json';
+            if (input === 'service') return 'service-456';
+            if (input === 'cluster') return 'cluster-789';
+            if (input === 'wait-for-service-stability') return 'true';
+            return '';
+        });
+
+        mockEcsDescribeServices
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [{ id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' }]
+                }]
+            }))
+            .mockImplementationOnce(() => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deployments: [
+                        { id: 'deployment-old-1', status: 'PRIMARY', rolloutState: 'COMPLETED' },
+                        { id: 'deployment-new-1', status: 'ACTIVE', rolloutState: 'FAILED', rolloutStateReason: 'Circuit breaker triggered' }
+                    ]
+                }]
+            }));
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(1);
+        expect(core.setFailed).toHaveBeenCalledWith(
+            expect.stringContaining('FAILED')
+        );
+    });
+
+    test('skips deployment verification when no new deployment is created', async () => {
+        core.getInput = jest.fn(input => {
+            if (input === 'task-definition') return 'task-definition.json';
+            if (input === 'service') return 'service-456';
+            if (input === 'cluster') return 'cluster-789';
+            if (input === 'wait-for-service-stability') return 'true';
+            return '';
+        });
+
+        // Same deployment ID before and after — no new deployment
+        mockEcsUpdateService.mockImplementation(() => Promise.resolve({
+            service: {
+                deployments: [{
+                    id: 'deployment-old-1',
+                    status: 'PRIMARY',
+                    rolloutState: 'COMPLETED'
+                }]
+            }
+        }));
+
+        await run();
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        // describeServices should only be called once (before update), not for verification
+        expect(mockEcsDescribeServices).toHaveBeenCalledTimes(1);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "aws-actions-amazon-ecs-deploy-task-definition",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.1",


### PR DESCRIPTION
*Issue #, if available:*

Fixes #191.

*Description of changes:*

## Problem

When a service has the deployment circuit breaker with rollback enabled, a failed deployment triggers a rollback. The service becomes stable again on the previous task definition, and the action reports **success** — even though the deployment actually failed.

## Fix

After `waitUntilServicesStable`, verify the deployment actually succeeded:

1. Before `updateService`, capture the current PRIMARY deployment ID
2. From the `updateService` response, capture the new PRIMARY deployment ID
3. If the IDs differ (a new deployment was created), call `describeServices` after stability and check:
   - Deployment not found → rolled back by circuit breaker → **fail**
   - `rolloutState: FAILED` → **fail**
   - Otherwise → success

This uses deployment ID comparison instead of task definition ARN comparison, which correctly handles `force-new-deployment` , EBS volume changes where the task definition doesn't change across deployments, and anything that would create a deployment that is added to ECS logic in the future.

No new API permissions required — uses the existing `ecs:DescribeServices` permission.

## Testing

- Updated existing unit tests to include deployment data in mocks
- Added unit tests for: rollback detection, FAILED rolloutState, and no-new-deployment skip
- Used my own AWS account for E2E validation with a Fargate service with circuit breaker + rollback enabled, deploying a broken image and confirming the action correctly fails

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.