### PR TITLE
test: Add rollback detection integration test

### DIFF
--- a/task-definition-bad-image.json
+++ b/task-definition-bad-image.json
@@ -1,0 +1,32 @@
+{
+  "containerDefinitions": [
+    {
+      "entryPoint": [
+        "sh",
+        "-c"
+      ],
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": [
+        "echo hello"
+      ],
+      "cpu": 256,
+      "memoryReservation": 512,
+      "image": "httpd:does-not-exist-99999",
+      "essential": true,
+      "name": "sample-app"
+    }
+  ],
+  "memory": "512",
+  "family": "github-actions-deploy-task-def-integ-tests",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "cpu": "256"
+}

--- a/test-workflow.yml
+++ b/test-workflow.yml
@@ -54,6 +54,24 @@ jobs:
         wait-for-task-stopped: true
         enable-ecs-managed-tags: true
 
+    - name: Deploy bad image to test rollback detection
+      id: bad-deploy
+      continue-on-error: true
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition: task-definition-bad-image.json
+        service: github-actions-deploy-task-def-integ-test
+        cluster: github-actions-deploy-task-def-integ-test
+        wait-for-service-stability: true
+
+    - name: Verify rollback was detected
+      run: |
+        if [ "${{ steps.bad-deploy.outcome }}" != "failure" ]; then
+          echo "::error::Expected deployment to fail due to rollback detection, but outcome was: ${{ steps.bad-deploy.outcome }}"
+          exit 1
+        fi
+        echo "Rollback correctly detected"
+
     - name: Deploy Amazon ECS task definition with ECS Service
       uses: aws-actions/amazon-ecs-deploy-task-definition@v2
       with:


### PR DESCRIPTION
Here's a description based on what we built and tested:


*Issue #, if available:*

#860

*Description of changes:*

Adds an integration test for the deployment rollback detection feature introduced in #860.

- Adds `task-definition-bad-image.json` with a nonexistent image (`httpd:does-not-exist-99999`) to trigger the deployment circuit breaker
- Adds a workflow step that deploys the bad image and verifies the action correctly detects the rollback
- The bad deploy step is ordered before the existing good service deploy so the service recovers for subsequent tests
- Verified on a fork: https://github.com/NahutabDevelop/amazon-ecs-deploy-task-definition/actions/runs/25117119139

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
