### PR TITLE
docs: correct the default waiter max delay for wait-max-delay-seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ This is particularly useful in cases where ECS or a previous task definition app
 
 ## Polling Configuration
 
-By default when waiting for service stability or task completion, the AWS SDK uses exponential backoff which can result in delays up to 120 seconds between polling attempts. This means even after your service becomes stable, you may wait up to 2 minutes before the next poll detects it.
+By default when waiting for service stability or task completion, the AWS SDK uses exponential backoff between polling attempts. For the ECS waiters the delay grows up to 600 seconds (10 minutes) in `@aws-sdk/client-ecs` v3.995.0 and later, which this action bundles as of v2.6.3. Once the backoff reaches that maximum, polls are 10 minutes apart, so even after your service becomes stable you may wait several minutes before the next poll detects it and the job finishes. CodeDeploy deployments are not affected: the CodeDeploy waiter still backs off up to 120 seconds.
 
 To use consistent polling intervals instead, set `wait-max-delay-seconds`:
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'How long to wait for the ECS service to reach stable state, in minutes (default: 30 minutes, max: 6 hours). For CodeDeploy deployments, any wait time configured in the CodeDeploy deployment group will be added to this value.'
     required: false
   wait-max-delay-seconds:
-    description: 'Maximum delay in seconds between polling attempts when waiting for service stability or task completion. If not set, AWS SDK uses exponential backoff up to 120 seconds. Set to 15 for consistent 15-second polling intervals.'
+    description: 'Maximum delay in seconds between polling attempts when waiting for service stability or task completion. If not set, the AWS SDK applies exponential backoff up to the waiter default maximum delay, which is 600 seconds (10 minutes) for the ECS waiters and 120 seconds for CodeDeploy deployments. Set to 15 for consistent 15-second polling intervals.'
     required: false
   codedeploy-appspec:
     description: "The path to the AWS CodeDeploy AppSpec file, if the ECS service uses the CODE_DEPLOY deployment controller. Will default to 'appspec.yaml'."


### PR DESCRIPTION
*Issue #, if available:* #872

*Description of changes:*

The docs for `wait-max-delay-seconds` say that, when the input is not set, the AWS SDK backs off "up to 120 seconds". That has not been true since v2.6.3 - the ECS waiters now back off up to 600 seconds (10 minutes). This implements the documentation fix suggested by @stephaneseng in #872. Docs only, no behavior change.

**When the value changed**

`@aws-sdk/client-ecs` v3.995.0 (aws/aws-sdk-js-v3@20258a5, released 2026-02-20, "feat(client-ecs): Migrated to Smithy. No functional changes") raised the waiter service defaults:

```diff
// clients/client-ecs/src/waiters/waitForServicesStable.ts
-  const serviceDefaults = { minDelay: 15, maxDelay: 120 };
+  const serviceDefaults = { minDelay: 15, maxDelay: 600 };
```

The same applies to `waitForServicesInactive`, `waitForTasksRunning` and `waitForTasksStopped`. The value originates in the Smithy model (`codegen/sdk-codegen/aws-models/ecs.json`, `smithy.waiters#waitable` -> `maxDelay: 600`).

This action picked it up in v2.6.3:

| action | released | @aws-sdk/client-ecs | ECS waiter maxDelay |
| --- | --- | --- | --- |
| v2.6.2 | 2026-04-30 | ^3.908.0 | 120s |
| v2.6.3 | 2026-07-01 | ^3.1076.0 | 600s |

**Why it matters**

With `minDelay: 15` / `maxDelay: 600`, `@smithy/util-waiter` computes `attemptCountCeiling = log2(600 / 15) + 1` (about 6.3), so from the 7th attempt onward every poll is a flat 600 seconds apart. A service that reaches steady state a few minutes into a deployment can therefore go unnoticed for minutes afterwards, which is the symptom reported in #872.

CodeDeploy deployments are not affected: `waitForDeploymentSuccessful` in `@aws-sdk/client-codedeploy` still uses `{ minDelay: 15, maxDelay: 120 }`, because the CodeDeploy model does not set `maxDelay` and the Smithy default applies. The current wording does not make that distinction, so the new text scopes the 600 second value to the ECS waiters.

**Notes**

- Docs only - `dist/` is not affected and does not need rebuilding.
- Related: #872 (open), #839 (the PR that added this input).
- Possible follow-up: the action already hardcodes `minDelay = WAIT_DEFAULT_DELAY_SEC` (15) but leaves `maxDelay` to the SDK default, so users who never set `wait-max-delay-seconds` still hit the 10-minute gap. Defaulting `maxDelay` as well would fix it for everyone - happy to open that as a separate PR if maintainers want it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.