### PR TITLE
harden: the github action retrieves multiple configurat... in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,19 @@ async function runTask(ecs, clusterName, taskDefArn, waitForMinutes, enableECSMa
   const waitForTask = core.getInput('wait-for-task-stopped', { required: false }) || 'false';
   const startedBy = core.getInput('run-task-started-by', { required: false }) || 'GitHub-Actions';
   const launchType = core.getInput('run-task-launch-type', { required: false }) || 'FARGATE';
+  const ALLOWED_LAUNCH_TYPES = ['FARGATE', 'EC2', 'EXTERNAL', ''];
+  if (!ALLOWED_LAUNCH_TYPES.includes(launchType)) {
+    throw new Error(`Invalid run-task-launch-type '${launchType}'. Must be one of: FARGATE, EC2, EXTERNAL`);
+  }
+  const RESOURCE_ID_LIST_PATTERN = /^[A-Za-z0-9\-,]*$/;
   const subnetIds = core.getInput('run-task-subnets', { required: false }) || '';
+  if (!RESOURCE_ID_LIST_PATTERN.test(subnetIds)) {
+    throw new Error('Invalid run-task-subnets value. Must be a comma-separated list of subnet IDs');
+  }
   const securityGroupIds = core.getInput('run-task-security-groups', { required: false }) || '';
+  if (!RESOURCE_ID_LIST_PATTERN.test(securityGroupIds)) {
+    throw new Error('Invalid run-task-security-groups value. Must be a comma-separated list of security group IDs');
+  }
   const containerOverrides = JSON.parse(core.getInput('run-task-container-overrides', { required: false }) || '[]');
   const assignPublicIP = core.getInput('run-task-assign-public-IP', { required: false }) || 'DISABLED';
   const tags = JSON.parse(core.getInput('run-task-tags', { required: false }) || '[]');


### PR DESCRIPTION
## Summary
Harden input handling in `index.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `index.js:27` |
| **Assessment** | Defensive hardening |
| **Chain Complexity** | 2-step |

**Description**: The GitHub Action retrieves multiple configuration parameters via core.getInput() without validation. Parameters like subnetIds, securityGroupIds, launchType, and JSON-parsed inputs are passed directly to AWS ECS API calls without format validation or allowlist checks.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `index.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
