### PR TITLE
feat: add task-definition-arn input for existing revisions (Issue #882)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Registers an Amazon ECS task definition and deploys it to an ECS service.
 
 - [Usage](#usage)
     + [Task definition file](#task-definition-file)
+    + [Deploying an existing task definition revision](#deploying-an-existing-task-definition-revision)
     + [Task definition container image values](#task-definition-container-image-values)
 - [Credentials and Region](#credentials-and-region)
 - [Permissions](#permissions)
@@ -58,6 +59,24 @@ If you do not wish to store your task definition as a file in your git repositor
       run: |
         aws ecs describe-task-definition --task-definition my-task-definition-family --query taskDefinition > task-definition.json
 ```
+
+### Deploying an existing task definition revision
+
+If the task definition revision you want to deploy is already registered in ECS, use `task-definition-arn` instead of `task-definition`. The action skips `RegisterTaskDefinition` entirely and deploys the revision as-is, which is useful for promoting an already-tested revision between environments or for rolling back to a known-good revision.
+
+```yaml
+    - name: Deploy an existing task definition revision
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+      with:
+        task-definition-arn: arn:aws:ecs:us-east-2:123456789012:task-definition/my-task-definition-family:7
+        service: my-service
+        cluster: my-cluster
+        wait-for-service-stability: true
+```
+
+For rolling (`ECS` deployment controller) deployments and one-off `run-task` invocations, a `family:revision` pair or a bare family name is also accepted, because ECS resolves those itself. For blue/green (`CODE_DEPLOY`) deployments, pass the full ARN: the value is written into the AppSpec `TaskDefinition` property, which requires an ARN.
+
+`task-definition` and `task-definition-arn` are mutually exclusive. At least one is required, and if both are supplied, `task-definition` takes precedence and a new revision is registered from the file. The `task-definition-arn` output is set in both cases, so downstream steps do not need to know which input was used.
 
 ### Task definition container image values
 

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,11 @@ branding:
   color: 'orange'
 inputs:
   task-definition:
-    description: 'The path to the ECS task definition file to register.'
-    required: true
+    description: 'The path to the ECS task definition file to register. Mutually exclusive with task-definition-arn; if both are given, this file takes precedence.'
+    required: false
+  task-definition-arn:
+    description: 'The full Amazon Resource Name (ARN) of an already-registered task definition to deploy. Use instead of task-definition to deploy an existing revision without registering a new one.'
+    required: false
   desired-count:
     description: 'The number of instantiations of the task to place and keep running in your service.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -529,7 +529,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 async function run() {
   try {
     // Get inputs
-    const taskDefinitionFile = core.getInput('task-definition', { required: true });
+    const taskDefinitionFile = core.getInput('task-definition', { required: false });
+    const taskDefinitionArn = core.getInput('task-definition-arn', { required: false });
     const service = core.getInput('service', { required: false });
     const cluster = core.getInput('cluster', { required: false });
     const maxRetries = parseInt(core.getInput('max-retries', { required: false })) || 3;
@@ -576,23 +577,31 @@ async function run() {
       retryMode: 'standard'
     });
 
-    // Register the task definition
-    core.debug('Registering the task definition');
-    const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-      taskDefinitionFile :
-      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
-    const fileContents = fs.readFileSync(taskDefPath, 'utf8');
-    const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents), keepNullValueKeys)));
-    let registerResponse;
-    try {
-      registerResponse = await ecs.registerTaskDefinition(taskDefContents);
-    } catch (error) {
-      core.setFailed("Failed to register task definition in ECS: " + error.message);
-      core.debug("Task definition contents:");
-      core.debug(JSON.stringify(taskDefContents, undefined, 4));
-      throw(error);
+    let taskDefArn;
+    if (taskDefinitionFile) {
+      core.info('The task definition file will be registered.');
+      core.debug('Registering the task definition');
+      const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
+        taskDefinitionFile :
+        path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+      const fileContents = fs.readFileSync(taskDefPath, 'utf8');
+      const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents), keepNullValueKeys)));
+      let registerResponse;
+      try {
+        registerResponse = await ecs.registerTaskDefinition(taskDefContents);
+      } catch (error) {
+        core.setFailed("Failed to register task definition in ECS: " + error.message);
+        core.debug("Task definition contents:");
+        core.debug(JSON.stringify(taskDefContents, undefined, 4));
+        throw(error);
+      }
+      taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
+    } else if (taskDefinitionArn) {
+      core.info('The task definition arn will be deployed without registering a new revision.');
+      taskDefArn = taskDefinitionArn;
+    } else {
+      throw new Error('Either task definition or task definition arn must be provided');
     }
-    const taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
     core.setOutput('task-definition-arn', taskDefArn);
 
     // Run the task outside of the service

--- a/index.js
+++ b/index.js
@@ -523,7 +523,8 @@ async function createCodeDeployDeployment(codedeploy, clusterName, service, task
 async function run() {
   try {
     // Get inputs
-    const taskDefinitionFile = core.getInput('task-definition', { required: true });
+    const taskDefinitionFile = core.getInput('task-definition', { required: false });
+    const taskDefinitionArn = core.getInput('task-definition-arn', { required: false });
     const service = core.getInput('service', { required: false });
     const cluster = core.getInput('cluster', { required: false });
     const maxRetries = parseInt(core.getInput('max-retries', { required: false })) || 3;
@@ -570,23 +571,31 @@ async function run() {
       retryMode: 'standard'
     });
 
-    // Register the task definition
-    core.debug('Registering the task definition');
-    const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
-      taskDefinitionFile :
-      path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
-    const fileContents = fs.readFileSync(taskDefPath, 'utf8');
-    const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents), keepNullValueKeys)));
-    let registerResponse;
-    try {
-      registerResponse = await ecs.registerTaskDefinition(taskDefContents);
-    } catch (error) {
-      core.setFailed("Failed to register task definition in ECS: " + error.message);
-      core.debug("Task definition contents:");
-      core.debug(JSON.stringify(taskDefContents, undefined, 4));
-      throw(error);
+    let taskDefArn;
+    if (taskDefinitionFile) {
+      core.info('The task definition file will be registered.');
+      core.debug('Registering the task definition');
+      const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
+        taskDefinitionFile :
+        path.join(process.env.GITHUB_WORKSPACE, taskDefinitionFile);
+      const fileContents = fs.readFileSync(taskDefPath, 'utf8');
+      const taskDefContents = maintainValidObjects(removeIgnoredAttributes(cleanNullKeys(yaml.parse(fileContents), keepNullValueKeys)));
+      let registerResponse;
+      try {
+        registerResponse = await ecs.registerTaskDefinition(taskDefContents);
+      } catch (error) {
+        core.setFailed("Failed to register task definition in ECS: " + error.message);
+        core.debug("Task definition contents:");
+        core.debug(JSON.stringify(taskDefContents, undefined, 4));
+        throw(error);
+      }
+      taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
+    } else if (taskDefinitionArn) {
+      core.info('The task definition arn will be deployed without registering a new revision.');
+      taskDefArn = taskDefinitionArn;
+    } else {
+      throw new Error('Either task definition or task definition arn must be provided');
     }
-    const taskDefArn = registerResponse.taskDefinition.taskDefinitionArn;
     core.setOutput('task-definition-arn', taskDefArn);
 
     // Run the task outside of the service

--- a/index.test.js
+++ b/index.test.js
@@ -57,6 +57,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('3');                   // max-retries
@@ -206,6 +207,100 @@ describe('Deploy to ECS', () => {
         });
         expect(waitUntilServicesStable).toHaveBeenCalledTimes(0);
         expect(core.info).toBeCalledWith("Deployment started. Watch this deployment's progress in the Amazon ECS console: https://fake-region.console.aws.amazon.com/ecs/v2/clusters/cluster-789/services/service-456/deployments?region=fake-region");
+    });
+
+    test('deploys a pre-registered task definition arn without registering a new revision', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('')                     // task-definition
+            .mockReturnValueOnce('arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7') // task-definition-arn
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('3');                   // max-retries
+
+        await run();
+
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenCalledTimes(0);
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7');
+        expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, {
+            cluster: 'cluster-789',
+            service: 'service-456',
+            taskDefinition: 'arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7',
+            forceNewDeployment: false,
+            enableECSManagedTags: null,
+            propagateTags: null,
+            volumeConfigurations: []
+        });
+    });
+
+    test('registers the task definition file when both task-definition and task-definition-arn are provided', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7') // task-definition-arn
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('3');                   // max-retries
+
+        await run();
+
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family' });
+        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(mockEcsUpdateService).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            taskDefinition: 'task:def:arn'
+        }));
+    });
+
+    test('fails when neither task-definition nor task-definition-arn is provided', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('')                     // task-definition
+            .mockReturnValueOnce('')                     // task-definition-arn
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('3');                   // max-retries
+
+        await run();
+
+        expect(core.setFailed).toHaveBeenCalledWith('Either task definition or task definition arn must be provided');
+        expect(mockEcsRegisterTaskDef).toHaveBeenCalledTimes(0);
+        expect(mockEcsUpdateService).toHaveBeenCalledTimes(0);
+    });
+
+    test('creates a CodeDeploy deployment from a pre-registered task definition arn', async () => {
+        core.getInput = jest
+            .fn()
+            .mockReturnValueOnce('')                     // task-definition
+            .mockReturnValueOnce('arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7') // task-definition-arn
+            .mockReturnValueOnce('service-456')          // service
+            .mockReturnValueOnce('cluster-789')          // cluster
+            .mockReturnValueOnce('3');                   // max-retries
+
+        mockEcsDescribeServices.mockImplementation(
+            () => Promise.resolve({
+                failures: [],
+                services: [{
+                    status: 'ACTIVE',
+                    deploymentController: {
+                        type: 'CODE_DEPLOY'
+                    }
+                }]
+            })
+        );
+
+        await run();
+
+        expect(core.setFailed).toHaveBeenCalledTimes(0);
+        expect(mockEcsRegisterTaskDef).toHaveBeenCalledTimes(0);
+        expect(mockCodeDeployCreateDeployment).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            revision: expect.objectContaining({
+                appSpecContent: expect.objectContaining({
+                    content: expect.stringContaining('arn:aws:ecs:fake-region:111122223333:task-definition/task-def-family:7')
+                })
+            })
+        }));
     });
 
     test('registers the task definition contents and updates the service if deployment controller type is ECS', async () => {
@@ -640,6 +735,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')         // service
             .mockReturnValueOnce('cluster-789')         // cluster
             .mockReturnValueOnce('3')                   // max-retries
@@ -718,6 +814,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')         // service
             .mockReturnValueOnce('cluster-789')         // cluster
             .mockReturnValueOnce('3')                   // max-retries
@@ -795,6 +892,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')         // service
             .mockReturnValueOnce('cluster-789')         // cluster
             .mockReturnValueOnce('3')                   // max-retries
@@ -1110,7 +1208,7 @@ describe('Deploy to ECS', () => {
     });
 
     test('registers the task definition contents at an absolute path', async () => {
-        core.getInput = jest.fn().mockReturnValueOnce('/hello/task-definition.json');
+        core.getInput = jest.fn().mockReturnValueOnce('/hello/task-definition.json').mockReturnValueOnce('');
         fs.readFileSync.mockImplementation((pathInput, encoding) => {
             if (encoding != 'utf8') {
                 throw new Error(`Wrong encoding ${encoding}`);
@@ -1134,6 +1232,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('3')                    // max-retries
@@ -1178,6 +1277,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('3')                    // max-retries
@@ -1237,6 +1337,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('cluster-789')          // cluster
             .mockReturnValueOnce('3')                    // max-retries
@@ -1371,6 +1472,7 @@ describe('Deploy to ECS', () => {
         core.getInput = jest
             .fn()
             .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce('') // task-definition-arn
             .mockReturnValueOnce('service-456')          // service
             .mockReturnValueOnce('');                    // desired count
 
@@ -1397,7 +1499,8 @@ describe('Deploy to ECS', () => {
     test('does not update service if none specified', async () => {
         core.getInput = jest
             .fn()
-            .mockReturnValueOnce('task-definition.json'); // task-definition
+            .mockReturnValueOnce('task-definition.json') // task-definition
+            .mockReturnValueOnce(''); // task-definition-arn
 
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
[Issue 882 - Add task-definition-arn input to deploy an existing revision](https://github.com/aws-actions/amazon-ecs-deploy-task-definition/issues/882)

### Context

Today `task-definition` is a required input, so the action always calls `RegisterTaskDefinition`. That means there is no way to deploy a task definition revision that is already registered — you have to re-register an identical revision to deploy it, which creates a new revision number every time.

Two cases where this gets in the way:

- **Promoting a revision between environments.** We register and test a revision once, then want to deploy that exact revision to the next environment, rather than re-registering from a file and hoping the two are identical.
- **Rolling back.** Rolling back to a known-good revision means pointing the service at an ARN that already exists. Re-registering to achieve that defeats the purpose.

### Implementation

Adds a `task-definition-arn` input as an alternative to `task-definition`. When it is set, the action skips `RegisterTaskDefinition` and deploys the given revision as-is.

`task-definition` becomes `required: false`, since one of the two inputs is now sufficient. Existing workflows are unaffected: passing `task-definition` behaves exactly as before. The only difference is that omitting both is now reported by the action rather than by the runner.

The behaviour follows the convention already established in [`aws-actions/amazon-ecs-render-task-definition`](https://github.com/aws-actions/amazon-ecs-render-task-definition), which accepts this same pair of inputs, so the two actions stay consistent for anyone using them together:

- both inputs are `required: false`
- if both are supplied, `task-definition` takes precedence and a new revision is registered from the file
- `core.info` names which source was used
- if neither is supplied, the action throws and `run()`'s existing `catch` surfaces it through `core.setFailed`, with wording that matches the sibling action

The `task-definition-arn` **output** is still set on both paths, so downstream steps do not need to know which input was used.

One documented limitation: for rolling (`ECS`) deployments and `run-task`, a `family:revision` pair or a bare family name also works, because ECS resolves those itself. For blue/green (`CODE_DEPLOY`) deployments the full ARN is required, because the value is written into the AppSpec `TaskDefinition` property. This is noted in the README.

### Testing

Added four unit tests covering the new paths: deploying a pre-registered ARN without registering, `task-definition` winning when both are supplied, the error when neither is supplied, and the ARN reaching the CodeDeploy AppSpec. Existing tests are unchanged apart from the positional `core.getInput` mocks, which needed one extra entry for the new input.

The full suite passes (55 tests) and `dist/index.js` is rebuilt with `npm run package`.

We have been running this behaviour in a fork for some time. This PR is that change reimplemented against the current `master`, so the code here is new even though the behaviour is not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.